### PR TITLE
Apply design tokens to frontend styles

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -138,7 +138,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-primary-dark to-gray-900">
-        <div className="animate-spin rounded-full h-12 w-12 border-4 border-gray-300 border-t-primary"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-4 border-neutral-200 border-t-primary"></div>
       </div>
     );
   }
@@ -198,7 +198,7 @@ export const LoginForm: React.FC = () => {
           <h2 className="text-h2 font-bold text-white mb-2">
             {isLogin ? 'Iniciar Sesión' : 'Crear Cuenta'}
           </h2>
-          <p className="text-gray-300">
+          <p className="text-neutral-200">
             {isLogin ? 'Accede a tu cuenta de Anclora Metaform' : 'Únete a Anclora Metaform'}
           </p>
         </div>
@@ -297,9 +297,9 @@ export const LoginForm: React.FC = () => {
         </form>
 
         {/* Usuario de prueba */}
-        <div className="bg-gray-800/30 backdrop-blur-sm rounded-lg border border-gray-700/50 p-4">
-          <h3 className="text-gray-300 font-medium mb-2">Usuario de Prueba:</h3>
-          <p className="text-gray-400 text-sm">
+        <div className="bg-neutral-800/30 backdrop-blur-sm rounded-lg border border-neutral-700/50 p-4">
+          <h3 className="text-neutral-200 font-medium mb-2">Usuario de Prueba:</h3>
+          <p className="text-neutral-600 text-sm">
             Email: ancoratest@dominio.com<br />
             Contraseña: Ancoratest123
           </p>
@@ -328,26 +328,26 @@ export const UserProfile: React.FC = () => {
       </div>
 
       <div className="space-y-4">
-        <div className="p-4 bg-gray-800/30 rounded-lg">
+        <div className="p-4 bg-neutral-800/30 rounded-lg">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <span className="text-gray-400 block text-sm">Nombre:</span>
+              <span className="text-neutral-600 block text-sm">Nombre:</span>
               <span className="text-white font-medium">{user.full_name}</span>
             </div>
             <div>
-              <span className="text-gray-400 block text-sm">Email:</span>
+              <span className="text-neutral-600 block text-sm">Email:</span>
               <span className="text-white font-medium">{user.email}</span>
             </div>
             <div>
-              <span className="text-gray-400 block text-sm">Plan:</span>
+              <span className="text-neutral-600 block text-sm">Plan:</span>
               <span className="text-primary font-medium">{user.plan_info.name}</span>
             </div>
             <div>
-              <span className="text-gray-400 block text-sm">Créditos:</span>
+              <span className="text-neutral-600 block text-sm">Créditos:</span>
               <span className="text-success font-bold">{user.credits}</span>
             </div>
             <div>
-              <span className="text-gray-400 block text-sm">Conversiones realizadas:</span>
+              <span className="text-neutral-600 block text-sm">Conversiones realizadas:</span>
               <span className="text-white font-medium">{user.total_conversions}</span>
             </div>
           </div>
@@ -355,8 +355,8 @@ export const UserProfile: React.FC = () => {
         
         <div className="mt-6">
           <h3 className="text-h4 text-white mb-4">Actividad Reciente</h3>
-          <div className="bg-gray-800/30 rounded-lg overflow-hidden">
-            <div className="p-4 text-center text-gray-400">
+          <div className="bg-neutral-800/30 rounded-lg overflow-hidden">
+            <div className="p-4 text-center text-neutral-600">
               <p>Historial de actividad disponible próximamente</p>
             </div>
           </div>

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -19,7 +19,7 @@ const Navigation: React.FC<{
   ];
 
   return (
-    <nav className="bg-slate-800/50 backdrop-blur-sm border-b border-slate-700/50">
+    <nav className="bg-neutral-800/50 backdrop-blur-sm border-b border-neutral-700/50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo con tipografía Inter y colores de marca */}
@@ -27,7 +27,7 @@ const Navigation: React.FC<{
             <h1 className="text-2xl font-bold text-white font-inter">
               🎯 Anclora Metaform
             </h1>
-            <span className="ml-2 text-gray-400 text-sm">Tu Contenido, Reinventado</span>
+            <span className="ml-2 text-neutral-600 text-sm">Tu Contenido, Reinventado</span>
           </div>
 
           {/* Navegación con colores primarios de la guía */}
@@ -39,7 +39,7 @@ const Navigation: React.FC<{
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
                   activeTab === tab.id
                     ? 'bg-primary text-white'
-                    : 'text-gray-300 hover:text-white hover:bg-slate-700/50'
+                    : 'text-neutral-200 hover:text-white hover:bg-neutral-700/50'
                 }`}
               >
                 <span className="mr-2">{tab.icon}</span>

--- a/frontend/src/components/AudioConverter.tsx
+++ b/frontend/src/components/AudioConverter.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 export const AudioConverter: React.FC = () => (
   <div className="p-4">
     <h2 className="text-xl font-semibold">Audio Converter</h2>
-    <p className="text-slate-600">This tool will allow you to convert audio files.</p>
+    <p className="text-neutral-700">This tool will allow you to convert audio files.</p>
   </div>
 );
 

--- a/frontend/src/components/ConversionHistory.tsx
+++ b/frontend/src/components/ConversionHistory.tsx
@@ -61,7 +61,7 @@ export const ConversionHistory: React.FC = () => {
       case 'completed': return 'text-green-400';
       case 'pending': return 'text-yellow-400';
       case 'failed': return 'text-red-400';
-      default: return 'text-slate-400';
+      default: return 'text-neutral-600';
     }
   };
 
@@ -88,7 +88,7 @@ export const ConversionHistory: React.FC = () => {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-        <span className="ml-3 text-slate-300">Cargando historial...</span>
+        <span className="ml-3 text-neutral-200">Cargando historial...</span>
       </div>
     );
   }
@@ -100,33 +100,33 @@ export const ConversionHistory: React.FC = () => {
         <h1 className="text-3xl font-bold text-white mb-2">
           📋 Historial de Conversiones
         </h1>
-        <p className="text-slate-300">
+        <p className="text-neutral-200">
           Todas tus conversiones realizadas
         </p>
       </div>
 
       {/* Estadísticas */}
       {user && (
-        <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
+        <div className="bg-neutral-800/30 backdrop-blur-sm rounded-xl border border-neutral-700/50 p-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
             <div>
               <div className="text-2xl font-bold text-blue-400">{user.total_conversions}</div>
-              <div className="text-slate-400">Total Conversiones</div>
+              <div className="text-neutral-600">Total Conversiones</div>
             </div>
             <div>
               <div className="text-2xl font-bold text-green-400">{user.credits}</div>
-              <div className="text-slate-400">Créditos Disponibles</div>
+              <div className="text-neutral-600">Créditos Disponibles</div>
             </div>
             <div>
               <div className="text-2xl font-bold text-purple-400">{user.credits_used_this_month}</div>
-              <div className="text-slate-400">Créditos Usados Este Mes</div>
+              <div className="text-neutral-600">Créditos Usados Este Mes</div>
             </div>
           </div>
         </div>
       )}
 
       {/* Lista de conversiones */}
-      <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
+      <div className="bg-neutral-800/30 backdrop-blur-sm rounded-xl border border-neutral-700/50 p-6">
         {error && (
           <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mb-6">
             <p className="text-red-400">{error}</p>
@@ -136,8 +136,8 @@ export const ConversionHistory: React.FC = () => {
         {conversions.length === 0 ? (
           <div className="text-center py-12">
             <div className="text-4xl mb-4 opacity-50">📁</div>
-            <p className="text-slate-400 mb-4">No hay conversiones aún</p>
-            <p className="text-slate-500 text-sm">
+            <p className="text-neutral-600 mb-4">No hay conversiones aún</p>
+            <p className="text-neutral-600 text-sm">
               Cuando realices tu primera conversión, aparecerá aquí
             </p>
           </div>
@@ -146,7 +146,7 @@ export const ConversionHistory: React.FC = () => {
             {conversions.map((conversion) => (
               <div 
                 key={conversion.id}
-                className="flex items-center justify-between p-4 bg-slate-700/30 hover:bg-slate-600/40 rounded-lg transition-colors border border-slate-700/30"
+                className="flex items-center justify-between p-4 bg-neutral-700/30 hover:bg-neutral-700/40 rounded-lg transition-colors border border-neutral-700/30"
               >
                 {/* Lado izquierdo - Información del archivo */}
                 <div className="flex items-center space-x-4">
@@ -162,12 +162,12 @@ export const ConversionHistory: React.FC = () => {
                     <p className="text-white font-medium">
                       {conversion.original_filename}
                     </p>
-                    <p className="text-slate-400 text-sm">
+                    <p className="text-neutral-600 text-sm">
                       {conversion.original_format.toUpperCase()} → {conversion.target_format.toUpperCase()} • 
                       {formatFileSize(conversion.file_size)} • 
                       {conversion.credits_used} créditos
                     </p>
-                    <p className="text-slate-500 text-xs">
+                    <p className="text-neutral-600 text-xs">
                       {formatDate(conversion.created_at)}
                       {conversion.processing_time && ` • ${conversion.processing_time.toFixed(1)}s`}
                     </p>
@@ -210,7 +210,7 @@ export const ConversionHistory: React.FC = () => {
           <button
             onClick={loadConversions}
             disabled={isLoading}
-            className="bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50"
+            className="bg-neutral-700 hover:bg-neutral-700 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50"
           >
             {isLoading ? 'Actualizando...' : 'Actualizar'}
           </button>

--- a/frontend/src/components/ConversionRouteDisplay.tsx
+++ b/frontend/src/components/ConversionRouteDisplay.tsx
@@ -32,7 +32,7 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
         key={path.path.join('-')}
         className={`
           p-4 rounded-lg border-2 cursor-pointer transition-all duration-200
-          ${isPrimary ? 'border-blue-500 bg-blue-50' : 'border-gray-200 bg-white'}
+          ${isPrimary ? 'border-blue-500 bg-blue-50' : 'border-neutral-200 bg-white'}
           ${isSelected ? 'ring-2 ring-blue-400' : ''}
           hover:border-blue-300 hover:shadow-md
         `}
@@ -59,7 +59,7 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
             <div className={`text-lg font-bold ${getQualityColor(path.estimatedQuality)}`}>
               {path.estimatedQuality}%
             </div>
-            <div className="text-xs text-gray-500">calidad</div>
+            <div className="text-xs text-neutral-600">calidad</div>
           </div>
         </div>
 
@@ -72,14 +72,14 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
                   px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap
                   ${index === 0 ? 'bg-blue-100 text-blue-800' : 
                     index === path.path.length - 1 ? 'bg-green-100 text-green-800' : 
-                    'bg-gray-100 text-gray-700'}
+                    'bg-neutral-200 text-neutral-700'}
                 `}>
                   {format.toUpperCase()}
                 </div>
               </div>
               {index < path.path.length - 1 && (
                 <div className="flex-shrink-0">
-                  <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 text-neutral-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>
                 </div>
@@ -89,7 +89,7 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
         </div>
 
         {/* Información adicional */}
-        <div className="flex items-center justify-between text-sm text-gray-600">
+        <div className="flex items-center justify-between text-sm text-neutral-700">
           <span>⏱️ ~{path.estimatedTime}s</span>
           <span>{path.description}</span>
         </div>
@@ -106,7 +106,7 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
 
   return (
     <div className="space-y-4">
-      <div className="text-lg font-semibold text-gray-800 mb-4">
+      <div className="text-lg font-semibold text-neutral-900 mb-4">
         Rutas de Conversión Disponibles
       </div>
 
@@ -116,7 +116,7 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
       {/* Rutas alternativas */}
       {alternativePaths.length > 0 && (
         <div className="space-y-3">
-          <div className="text-sm font-medium text-gray-600">
+          <div className="text-sm font-medium text-neutral-700">
             Rutas Alternativas ({alternativePaths.length})
           </div>
           {alternativePaths.map((path) => 
@@ -126,8 +126,8 @@ export const ConversionRouteDisplay: React.FC<ConversionRouteDisplayProps> = ({
       )}
 
       {/* Información adicional */}
-      <div className="mt-6 p-4 bg-gray-50 rounded-lg">
-        <div className="text-sm text-gray-600 space-y-2">
+      <div className="mt-6 p-4 bg-neutral-100 rounded-lg">
+        <div className="text-sm text-neutral-700 space-y-2">
           <div className="flex items-center gap-2">
             <span className="w-3 h-3 bg-green-500 rounded-full"></span>
             <span><strong>Conversión directa:</strong> Máxima calidad y velocidad</span>

--- a/frontend/src/components/ConversionSuccess.tsx
+++ b/frontend/src/components/ConversionSuccess.tsx
@@ -37,20 +37,20 @@ export const ConversionSuccess: React.FC<ConversionSuccessProps> = ({ fromFile, 
         <IconCheck className="w-10 h-10 text-green-600" />
       </div>
       <div>
-        <h2 className="text-2xl font-bold text-slate-800">Conversion Complete!</h2>
-        <p className="text-slate-500 mt-1">
-          Your file <span className="font-semibold text-slate-700">{fromFile}</span> has been converted to <span className="font-semibold text-slate-700">{toFormat}</span>.
+        <h2 className="text-2xl font-bold text-neutral-900">Conversion Complete!</h2>
+        <p className="text-neutral-600 mt-1">
+          Your file <span className="font-semibold text-neutral-700">{fromFile}</span> has been converted to <span className="font-semibold text-neutral-700">{toFormat}</span>.
         </p>
       </div>
 
-      <div className="w-full max-w-md bg-slate-50 border rounded-lg p-4">
-        <p className="font-mono text-slate-800 break-all">{getNewFileName()}</p>
+      <div className="w-full max-w-md bg-neutral-100 border rounded-lg p-4">
+        <p className="font-mono text-neutral-900 break-all">{getNewFileName()}</p>
       </div>
       
       <div className="w-full flex flex-col sm:flex-row sm:justify-center items-center space-y-4 sm:space-y-0 sm:space-x-4 pt-4">
         <button
             onClick={onReset}
-            className="w-full sm:w-auto order-2 sm:order-1 flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-slate-700 bg-slate-200 hover:bg-slate-300 transition-colors"
+            className="w-full sm:w-auto order-2 sm:order-1 flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-neutral-700 bg-neutral-200 hover:bg-neutral-300 transition-colors"
           >
             <IconRefresh className="w-5 h-5 mr-2" />
             Convert Another

--- a/frontend/src/components/CreditPurchase.tsx
+++ b/frontend/src/components/CreditPurchase.tsx
@@ -97,7 +97,7 @@ export const CreditPurchase: React.FC = () => {
         <h1 className="text-3xl font-bold text-white mb-2">
           💳 Gestión de Créditos
         </h1>
-        <p className="text-slate-300">
+        <p className="text-neutral-200">
           Compra créditos o actualiza tu plan de suscripción
         </p>
       </div>
@@ -108,18 +108,18 @@ export const CreditPurchase: React.FC = () => {
           <div className="text-center">
             <h2 className="text-xl font-bold text-white mb-2">Saldo Actual</h2>
             <div className="text-4xl font-bold text-blue-400 mb-2">{user.credits}</div>
-            <p className="text-slate-300">créditos disponibles</p>
+            <p className="text-neutral-200">créditos disponibles</p>
             <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
               <div>
-                <span className="text-slate-400">Plan actual: </span>
+                <span className="text-neutral-600">Plan actual: </span>
                 <span className="text-blue-400 font-medium">{user.plan_info.name}</span>
               </div>
               <div>
-                <span className="text-slate-400">Usados hoy: </span>
+                <span className="text-neutral-600">Usados hoy: </span>
                 <span className="text-white">{user.credits_used_today}</span>
               </div>
               <div>
-                <span className="text-slate-400">Total conversiones: </span>
+                <span className="text-neutral-600">Total conversiones: </span>
                 <span className="text-white">{user.total_conversions}</span>
               </div>
             </div>
@@ -139,7 +139,7 @@ export const CreditPurchase: React.FC = () => {
       )}
 
       {/* Paquetes de créditos */}
-      <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
+      <div className="bg-neutral-800/30 backdrop-blur-sm rounded-xl border border-neutral-700/50 p-6">
         <h2 className="text-2xl font-bold text-white mb-6 text-center">
           🎯 Paquetes de Créditos
         </h2>
@@ -151,7 +151,7 @@ export const CreditPurchase: React.FC = () => {
               className={`relative p-4 rounded-lg border transition-all duration-200 hover:scale-105 ${
                 pkg.popular 
                   ? 'bg-gradient-to-br from-blue-500/20 to-purple-500/20 border-blue-500/50' 
-                  : 'bg-slate-700/30 border-slate-600/30 hover:border-blue-500/30'
+                  : 'bg-neutral-700/30 border-neutral-700/30 hover:border-blue-500/30'
               }`}
             >
               {pkg.popular && (
@@ -166,7 +166,7 @@ export const CreditPurchase: React.FC = () => {
                 <div className="text-2xl font-bold text-white mb-1">
                   {pkg.credits + pkg.bonus}
                 </div>
-                <div className="text-slate-400 text-sm mb-2">créditos</div>
+                <div className="text-neutral-600 text-sm mb-2">créditos</div>
                 
                 {pkg.bonus > 0 && (
                   <div className="text-green-400 text-xs mb-2">
@@ -192,7 +192,7 @@ export const CreditPurchase: React.FC = () => {
       </div>
 
       {/* Planes de suscripción */}
-      <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
+      <div className="bg-neutral-800/30 backdrop-blur-sm rounded-xl border border-neutral-700/50 p-6">
         <h2 className="text-2xl font-bold text-white mb-6 text-center">
           🚀 Planes de Suscripción
         </h2>
@@ -204,7 +204,7 @@ export const CreditPurchase: React.FC = () => {
               className={`relative p-6 rounded-lg border transition-all duration-200 ${
                 plan.popular 
                   ? 'bg-gradient-to-br from-blue-500/20 to-purple-500/20 border-blue-500/50 scale-105' 
-                  : 'bg-slate-700/30 border-slate-600/30'
+                  : 'bg-neutral-700/30 border-neutral-700/30'
               }`}
             >
               {plan.popular && (
@@ -220,18 +220,18 @@ export const CreditPurchase: React.FC = () => {
                 <div className="text-3xl font-bold text-blue-400 mb-1">
                   €{plan.price}
                 </div>
-                <div className="text-slate-400 text-sm">por mes</div>
+                <div className="text-neutral-600 text-sm">por mes</div>
               </div>
               
               <div className="mb-6">
                 <div className="text-center mb-4">
                   <span className="text-lg font-bold text-green-400">{plan.credits}</span>
-                  <span className="text-slate-400 text-sm ml-1">créditos/mes</span>
+                  <span className="text-neutral-600 text-sm ml-1">créditos/mes</span>
                 </div>
                 
                 <ul className="space-y-2">
                   {plan.features.map((feature, index) => (
-                    <li key={index} className="flex items-center text-sm text-slate-300">
+                    <li key={index} className="flex items-center text-sm text-neutral-200">
                       <span className="text-green-400 mr-2">✓</span>
                       {feature}
                     </li>
@@ -244,7 +244,7 @@ export const CreditPurchase: React.FC = () => {
                 disabled={isLoading || user?.plan === plan.id}
                 className={`w-full py-2 px-4 rounded font-medium transition-colors ${
                   user?.plan === plan.id
-                    ? 'bg-gray-500 text-gray-300 cursor-not-allowed'
+                    ? 'bg-neutral-700 text-neutral-200 cursor-not-allowed'
                     : plan.popular
                     ? 'bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white'
                     : 'bg-blue-500 hover:bg-blue-600 text-white'
@@ -263,9 +263,9 @@ export const CreditPurchase: React.FC = () => {
       </div>
 
       {/* Información adicional */}
-      <div className="bg-slate-800/30 backdrop-blur-sm rounded-xl border border-slate-700/50 p-6">
+      <div className="bg-neutral-800/30 backdrop-blur-sm rounded-xl border border-neutral-700/50 p-6">
         <h3 className="text-lg font-bold text-white mb-4">ℹ️ Información sobre Créditos</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-slate-300">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-neutral-200">
           <div>
             <h4 className="font-medium text-white mb-2">¿Cómo funcionan los créditos?</h4>
             <ul className="space-y-1">

--- a/frontend/src/components/CreditSystem.tsx
+++ b/frontend/src/components/CreditSystem.tsx
@@ -256,27 +256,27 @@ export const CreditBalance: React.FC = () => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+    <div className="bg-white rounded-lg shadow-sm border border-neutral-200 p-4">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-lg font-semibold text-gray-900">Saldo de Créditos</h3>
+        <h3 className="text-lg font-semibold text-neutral-900">Saldo de Créditos</h3>
         <div className="flex items-center space-x-2">
           <span className="text-2xl font-bold text-blue-600">
             {balance.current.toLocaleString()}
           </span>
-          <span className="text-sm text-gray-500">créditos</span>
+          <span className="text-sm text-neutral-600">créditos</span>
         </div>
       </div>
       
       <div className="grid grid-cols-2 gap-4 text-sm">
         <div>
-          <span className="text-gray-600">Valor equivalente:</span>
-          <div className="font-medium text-gray-900">
+          <span className="text-neutral-700">Valor equivalente:</span>
+          <div className="font-medium text-neutral-900">
             {getCreditValue(balance.current)}
           </div>
         </div>
         <div>
-          <span className="text-gray-600">Total consumido:</span>
-          <div className="font-medium text-gray-900">
+          <span className="text-neutral-700">Total consumido:</span>
+          <div className="font-medium text-neutral-900">
             {balance.total_consumed.toLocaleString()}
           </div>
         </div>
@@ -339,20 +339,20 @@ export const ConversionCost: React.FC<ConversionCostProps> = ({
         : 'bg-red-50 border-red-200'
     }`}>
       <div className="flex items-center justify-between mb-2">
-        <h4 className="font-medium text-gray-900">Coste de Conversión</h4>
+        <h4 className="font-medium text-neutral-900">Coste de Conversión</h4>
         <div className="flex items-center space-x-2">
           <span className={`text-lg font-bold ${
             canAfford ? 'text-green-600' : 'text-red-600'
           }`}>
             {cost} créditos
           </span>
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-neutral-600">
             ({getCreditValue(cost)})
           </span>
         </div>
       </div>
       
-      <div className="grid grid-cols-2 gap-4 text-sm text-gray-600">
+      <div className="grid grid-cols-2 gap-4 text-sm text-neutral-700">
         <div>
           <span>Archivo: </span>
           <span className="font-medium">{fileName || 'archivo'}</span>
@@ -394,7 +394,7 @@ export const CreditHistory: React.FC = () => {
       case 'consumption': return 'text-red-400';
       case 'bonus': return 'text-blue-400';
       case 'refund': return 'text-purple-400';
-      default: return 'text-slate-400';
+      default: return 'text-neutral-600';
     }
   };
 
@@ -430,19 +430,19 @@ export const CreditHistory: React.FC = () => {
 
   return (
     <div className="p-8">
-      <div className="bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 rounded-xl">
+      <div className="bg-neutral-800/50 backdrop-blur-sm border border-neutral-700/50 rounded-xl">
         {/* Header con título centrado y botón de exportar */}
-        <div className="p-6 border-b border-slate-700/30 flex items-center justify-between">
+        <div className="p-6 border-b border-neutral-700/30 flex items-center justify-between">
           <div className="flex-1"></div>
           <h1 className="text-2xl font-bold text-unified-primary text-center">
             Historial de Créditos
           </h1>
           <div className="flex-1 flex justify-end">
             <button 
-              className="p-2 hover:bg-slate-700/50 rounded-lg transition-colors group"
+              className="p-2 hover:bg-neutral-700/50 rounded-lg transition-colors group"
               title="Exportar historial de créditos"
             >
-              <svg className="w-5 h-5 text-slate-400 group-hover:text-unified-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-neutral-600 group-hover:text-unified-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
               </svg>
             </button>
@@ -450,7 +450,7 @@ export const CreditHistory: React.FC = () => {
         </div>
 
         {/* Estadísticas */}
-        <div className="p-6 border-b border-slate-700/30 bg-gradient-to-r from-blue-500/10 to-purple-500/10">
+        <div className="p-6 border-b border-neutral-700/30 bg-gradient-to-r from-blue-500/10 to-purple-500/10">
           <div className="grid grid-cols-3 gap-4 text-center">
             <div>
               <div className="text-xl font-bold text-green-400">
@@ -484,7 +484,7 @@ export const CreditHistory: React.FC = () => {
             transactions.map((transaction) => (
               <div 
                 key={transaction.id}
-                className="flex items-center justify-between p-4 bg-slate-700/30 hover:bg-slate-600/40 rounded-lg transition-colors border border-slate-700/30"
+                className="flex items-center justify-between p-4 bg-neutral-700/30 hover:bg-neutral-700/40 rounded-lg transition-colors border border-neutral-700/30"
               >
                 {/* Lado izquierdo - Icono y detalles */}
                 <div className="flex items-center space-x-4">

--- a/frontend/src/components/DocToTextConverter.tsx
+++ b/frontend/src/components/DocToTextConverter.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 export const DocToTextConverter: React.FC = () => (
   <div className="p-4">
     <h2 className="text-xl font-semibold">Document to Text Converter</h2>
-    <p className="text-slate-600">Upload a document and get a text version back.</p>
+    <p className="text-neutral-700">Upload a document and get a text version back.</p>
   </div>
 );
 

--- a/frontend/src/components/EbookConverter.tsx
+++ b/frontend/src/components/EbookConverter.tsx
@@ -168,7 +168,7 @@ export const EbookConverter: React.FC<EbookConverterProps> = ({
       case 'processing':
         return <IconRefresh className="w-5 h-5 text-blue-600 animate-spin" />;
       default:
-        return <IconRefresh className="w-5 h-5 text-gray-400" />;
+        return <IconRefresh className="w-5 h-5 text-neutral-600" />;
     }
   };
 

--- a/frontend/src/components/FAQ.tsx
+++ b/frontend/src/components/FAQ.tsx
@@ -9,13 +9,13 @@ type FAQItemProps = {
 };
 
 const FAQItem: React.FC<FAQItemProps> = ({ question, answer, isOpen, onClick }) => (
-  <div className="border-b border-slate-200">
+  <div className="border-b border-neutral-200">
     <button onClick={onClick} className="w-full flex justify-between items-center text-left py-5">
-      <h3 className={`text-lg font-medium ${isOpen ? 'text-green-600' : 'text-slate-800'}`}>{question}</h3>
-      {isOpen ? <IconMinus className="w-6 h-6 text-green-600" /> : <IconPlus className="w-6 h-6 text-slate-500" />}
+      <h3 className={`text-lg font-medium ${isOpen ? 'text-green-600' : 'text-neutral-900'}`}>{question}</h3>
+      {isOpen ? <IconMinus className="w-6 h-6 text-green-600" /> : <IconPlus className="w-6 h-6 text-neutral-600" />}
     </button>
     {isOpen && (
-      <div className="pb-5 pr-8 text-slate-600">
+      <div className="pb-5 pr-8 text-neutral-700">
         <p>{answer}</p>
       </div>
     )}
@@ -73,11 +73,11 @@ export const FAQ: React.FC = () => {
 
     return (
         <section className="w-full max-w-4xl mx-auto py-16 sm:py-24">
-            <h2 className="text-3xl sm:text-4xl font-bold text-slate-800 tracking-tight text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold text-neutral-900 tracking-tight text-center mb-12">
                 ¿Puede que tenga algunas preguntas?
             </h2>
             <div className="bg-white rounded-2xl shadow-xl shadow-slate-200/50 ring-1 ring-slate-200/50 p-4 sm:p-8">
-                <div className="border-b border-slate-200">
+                <div className="border-b border-neutral-200">
                     <nav className="-mb-px flex space-x-8" aria-label="Tabs">
                         {tabs.map(tab => (
                             <button
@@ -86,7 +86,7 @@ export const FAQ: React.FC = () => {
                                 className={`whitespace-nowrap py-4 px-1 border-b-2 font-medium text-lg ${
                                     activeTab === tab 
                                     ? 'border-green-500 text-green-600' 
-                                    : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'
+                                    : 'border-transparent text-neutral-600 hover:text-neutral-700 hover:border-neutral-200'
                                 }`}
                             >
                                 {tab}
@@ -107,11 +107,11 @@ export const FAQ: React.FC = () => {
                 </div>
             </div>
 
-            <div className="mt-12 text-center bg-slate-100/70 rounded-lg p-8">
-                <h3 className="text-2xl font-bold text-slate-800">¿Todavía tienes una pregunta?</h3>
-                <p className="mt-2 text-slate-600">Si no puedes encontrar una respuesta a tu pregunta en nuestras preguntas frecuentes, siempre puedes contactarnos. ¡Estaremos encantados de responderte!</p>
+            <div className="mt-12 text-center bg-neutral-100/70 rounded-lg p-8">
+                <h3 className="text-2xl font-bold text-neutral-900">¿Todavía tienes una pregunta?</h3>
+                <p className="mt-2 text-neutral-700">Si no puedes encontrar una respuesta a tu pregunta en nuestras preguntas frecuentes, siempre puedes contactarnos. ¡Estaremos encantados de responderte!</p>
                 <div className="mt-6">
-                    <button className="px-6 py-3 border border-slate-300 text-slate-800 font-semibold rounded-lg hover:bg-white transition-colors">
+                    <button className="px-6 py-3 border border-neutral-200 text-neutral-900 font-semibold rounded-lg hover:bg-white transition-colors">
                         Contacto
                     </button>
                 </div>

--- a/frontend/src/components/Features.tsx
+++ b/frontend/src/components/Features.tsx
@@ -12,8 +12,8 @@ const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description }) =
     <div className="flex items-center justify-center w-20 h-20 bg-white rounded-2xl shadow-lg mb-6">
       {icon}
     </div>
-    <h3 className="text-2xl font-bold text-slate-800 mb-2">{title}</h3>
-    <p className="text-slate-600 text-center">{description}</p>
+    <h3 className="text-2xl font-bold text-neutral-900 mb-2">{title}</h3>
+    <p className="text-neutral-700 text-center">{description}</p>
   </div>
 );
 

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -76,7 +76,7 @@ export const FileUploader: React.FC<PropsWithChildren<FileUploaderProps>> = ({
   // Default drag-and-drop UI if no children are passed
   return (
     <div
-      className={`relative group transition-all duration-300 ${isDragging ? 'border-blue-500 scale-105 bg-blue-50' : 'border-slate-300 bg-slate-50/50 hover:border-blue-400'} border-2 border-dashed rounded-xl p-8 text-center ${isLoading ? 'cursor-wait' : 'cursor-pointer'}`}
+      className={`relative group transition-all duration-300 ${isDragging ? 'border-blue-500 scale-105 bg-blue-50' : 'border-neutral-200 bg-neutral-100/50 hover:border-blue-400'} border-2 border-dashed rounded-xl p-8 text-center ${isLoading ? 'cursor-wait' : 'cursor-pointer'}`}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { IconConverterLogo, IconEnvelope, IconChatBubble, IconVisa, IconMasterca
 
 const FooterLink: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => (
     <li>
-        <a href={href} className="text-slate-400 hover:text-white transition-colors">
+        <a href={href} className="text-neutral-600 hover:text-white transition-colors">
             {children}
         </a>
     </li>
@@ -11,12 +11,12 @@ const FooterLink: React.FC<{ href: string; children: React.ReactNode }> = ({ hre
 
 export const Footer: React.FC = () => {
     return (
-        <footer className="bg-slate-800 text-white">
+        <footer className="bg-neutral-800 text-white">
             <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="py-12 grid grid-cols-1 md:grid-cols-2 gap-12 border-b-2 border-slate-700">
+                <div className="py-12 grid grid-cols-1 md:grid-cols-2 gap-12 border-b-2 border-neutral-700">
                     <div>
                         <h3 className="text-xl font-bold mb-4">¿Todavía tienes una pregunta?</h3>
-                        <p className="text-slate-400">Póngase en contacto con nuestro amable equipo de soporte.</p>
+                        <p className="text-neutral-600">Póngase en contacto con nuestro amable equipo de soporte.</p>
                     </div>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
                         <div className="flex items-start space-x-4">
@@ -39,7 +39,7 @@ export const Footer: React.FC = () => {
                 <div className="py-12 grid grid-cols-2 md:grid-cols-5 gap-8">
                     <div className="col-span-2 md:col-span-1">
                         <IconConverterLogo className="w-12 h-12 text-green-400 mb-4" />
-                        <button className="w-full sm:w-auto flex items-center justify-between px-4 py-2 bg-slate-700 rounded-md text-left">
+                        <button className="w-full sm:w-auto flex items-center justify-between px-4 py-2 bg-neutral-700 rounded-md text-left">
                             <span>Español</span>
                             <IconChevronDown className="w-5 h-5" />
                         </button>
@@ -80,13 +80,13 @@ export const Footer: React.FC = () => {
                             <FooterLink href="#">Formatos Compatibles</FooterLink>
                             <FooterLink href="#">FAQ</FooterLink>
                         </ul>
-                        <a href="#" className="mt-6 inline-block w-full text-center px-4 py-2 border border-white rounded-md hover:bg-white hover:text-slate-800 font-semibold transition-colors">
+                        <a href="#" className="mt-6 inline-block w-full text-center px-4 py-2 border border-white rounded-md hover:bg-white hover:text-neutral-900 font-semibold transition-colors">
                             Iniciar sesión
                         </a>
                     </div>
                 </div>
 
-                <div className="py-8 flex flex-col md:flex-row justify-between items-center border-t-2 border-slate-700">
+                <div className="py-8 flex flex-col md:flex-row justify-between items-center border-t-2 border-neutral-700">
                     <div className="flex space-x-6">
                         <FooterLink href="#">Aviso legal</FooterLink>
                         <FooterLink href="#">Política de privacidad</FooterLink>
@@ -94,10 +94,10 @@ export const Footer: React.FC = () => {
                         <FooterLink href="#">Darse de baja</FooterLink>
                     </div>
                     <div className="flex items-center space-x-4 mt-6 md:mt-0">
-                        <span className="text-slate-400">Pagos seguros</span>
+                        <span className="text-neutral-600">Pagos seguros</span>
                         <IconVisa className="w-10 h-auto text-white" />
                         <IconMastercard className="w-10 h-auto text-white" />
-                        <p className="text-slate-400">&copy; 2023 online-file-converter.<br/>Todos los derechos reservados.</p>
+                        <p className="text-neutral-600">&copy; 2023 online-file-converter.<br/>Todos los derechos reservados.</p>
                     </div>
                 </div>
             </div>

--- a/frontend/src/components/FormatSelector.tsx
+++ b/frontend/src/components/FormatSelector.tsx
@@ -93,29 +93,29 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({ availableFormats
                 aria-haspopup="listbox"
                 aria-expanded={isOpen}
             >
-                <span className={selectedFormat ? 'text-green-700' : 'text-slate-500'}>
+                <span className={selectedFormat ? 'text-green-700' : 'text-neutral-600'}>
                     {selectedFormat || 'Selecciona tu formato'}
                 </span>
-                <IconChevronDown className={`w-6 h-6 text-slate-500 transition-transform duration-200 ${isOpen ? 'transform rotate-180' : ''}`} />
+                <IconChevronDown className={`w-6 h-6 text-neutral-600 transition-transform duration-200 ${isOpen ? 'transform rotate-180' : ''}`} />
             </button>
 
             {isOpen && (
-                <div className="absolute z-10 mt-2 w-[95vw] max-w-md sm:max-w-xl -translate-x-1/2 left-1/2 sm:left-auto sm:translate-x-0 bg-white border border-slate-200 rounded-lg shadow-2xl">
-                    <div className="p-3 border-b border-slate-200">
+                <div className="absolute z-10 mt-2 w-[95vw] max-w-md sm:max-w-xl -translate-x-1/2 left-1/2 sm:left-auto sm:translate-x-0 bg-white border border-neutral-200 rounded-lg shadow-2xl">
+                    <div className="p-3 border-b border-neutral-200">
                         <div className="relative">
-                            <IconSearch className="w-5 h-5 text-slate-400 absolute top-1/2 left-3 transform -translate-y-1/2" />
+                            <IconSearch className="w-5 h-5 text-neutral-600 absolute top-1/2 left-3 transform -translate-y-1/2" />
                             <input
                                 type="text"
                                 placeholder="Search"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-green-400 focus:border-green-400"
+                                className="w-full pl-10 pr-4 py-2 border border-neutral-200 rounded-md focus:ring-2 focus:ring-green-400 focus:border-green-400"
                                 autoFocus
                             />
                         </div>
                     </div>
                     <div className="flex" style={{ height: '350px' }}>
-                        <div className="w-1/3 border-r border-slate-200 p-2 space-y-1 overflow-y-auto">
+                        <div className="w-1/3 border-r border-neutral-200 p-2 space-y-1 overflow-y-auto">
                             {availableCategories.map(catKey => {
                                 const details = categoryDetails[catKey];
                                 if (!details || (catKey !== 'all' && !displayedFormatsByCategory[catKey]?.length)) return null;
@@ -127,7 +127,7 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({ availableFormats
                                     <button
                                         key={catKey}
                                         onClick={() => setActiveCategory(catKey)}
-                                        className={`w-full flex items-center space-x-3 text-left p-2 rounded-md transition-colors text-sm border-l-2 ${isActive ? 'bg-green-50 text-green-700 font-semibold border-green-500' : 'text-slate-600 hover:bg-slate-50 border-transparent'}`}
+                                        className={`w-full flex items-center space-x-3 text-left p-2 rounded-md transition-colors text-sm border-l-2 ${isActive ? 'bg-green-50 text-green-700 font-semibold border-green-500' : 'text-neutral-700 hover:bg-neutral-100 border-transparent'}`}
                                     >
                                         <Icon className="w-5 h-5 flex-shrink-0" />
                                         <span>{details.name}</span>
@@ -138,7 +138,7 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({ availableFormats
                         <div className="w-2/3 p-3 overflow-y-auto">
                             {noResults ? (
                                 <div className="flex items-center justify-center h-full">
-                                    <p className="text-slate-500 text-center">No matching formats.</p>
+                                    <p className="text-neutral-600 text-center">No matching formats.</p>
                                 </div>
                             ) : (
                                 <ul className="grid grid-cols-3 gap-2">
@@ -146,7 +146,7 @@ export const FormatSelector: React.FC<FormatSelectorProps> = ({ availableFormats
                                         <li key={format}>
                                             <button
                                                 onClick={() => handleSelect(format)}
-                                                className="w-full text-center px-2 py-3 border border-slate-200 bg-white text-slate-700 hover:bg-slate-100 hover:border-slate-300 rounded-md transition-colors"
+                                                className="w-full text-center px-2 py-3 border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-100 hover:border-neutral-200 rounded-md transition-colors"
                                                 role="option"
                                                 aria-selected={format === selectedFormat}
                                             >

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -46,9 +46,9 @@ export const Layout: React.FC<LayoutProps> = ({
   ];
 
   return (
-    <div className="flex h-screen bg-gray-900 text-white font-inter">
+    <div className="flex h-screen bg-neutral-900 text-white font-inter">
       {/* Sidebar */}
-      <aside className="hidden md:flex w-64 flex-shrink-0 bg-gray-800 flex-col">
+      <aside className="hidden md:flex w-64 flex-shrink-0 bg-neutral-800 flex-col">
         <div className="flex items-center p-4">
           <div className="w-10 h-10 rounded-lg bg-primary flex items-center justify-center text-white font-bold text-xl mr-3">
             A
@@ -70,9 +70,9 @@ export const Layout: React.FC<LayoutProps> = ({
             />
           ))}
         </nav>
-        <div className="p-4 border-t border-gray-700/50">
-          <h4 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-2">Actividad Hoy</h4>
-          <div className="flex justify-between text-xs text-gray-400">
+        <div className="p-4 border-t border-neutral-700/50">
+          <h4 className="text-xs font-bold text-neutral-600 uppercase tracking-wider mb-2">Actividad Hoy</h4>
+          <div className="flex justify-between text-xs text-neutral-600">
             <span>Conversiones</span>
             <span className="font-semibold text-white">47</span>
           </div>
@@ -83,7 +83,7 @@ export const Layout: React.FC<LayoutProps> = ({
       {mobileOpen && (
         <div className="fixed inset-0 z-50 flex md:hidden">
           <div className="absolute inset-0 bg-black/60" onClick={() => setMobileOpen(false)} />
-          <aside className="relative w-64 bg-gray-800 flex flex-col">
+          <aside className="relative w-64 bg-neutral-800 flex flex-col">
             <button className="self-end m-4" onClick={() => setMobileOpen(false)}>✕</button>
             <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
               {tabs.map((tab) => (
@@ -106,12 +106,12 @@ export const Layout: React.FC<LayoutProps> = ({
 
       {/* Main */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        <header className="flex items-center justify-end md:justify-end p-3 bg-gray-800 border-b border-gray-700/50">
+        <header className="flex items-center justify-end md:justify-end p-3 bg-neutral-800 border-b border-neutral-700/50">
           <button className="md:hidden mr-auto" onClick={() => setMobileOpen(true)} aria-label="Abrir menú">
             ☰
           </button>
           <div className="flex items-center space-x-3">
-            <div className="flex items-center text-sm font-semibold bg-gray-700/50 px-3 py-1.5 rounded-lg">
+            <div className="flex items-center text-sm font-semibold bg-neutral-700/50 px-3 py-1.5 rounded-lg">
               <span className="text-primary mr-2">💎</span>
               <span>{user?.credits || 50} créditos</span>
             </div>
@@ -122,7 +122,7 @@ export const Layout: React.FC<LayoutProps> = ({
               >
                 👤
               </button>
-              <span className="absolute -bottom-1 -right-1 w-3 h-3 bg-success rounded-full border-2 border-gray-800" />
+              <span className="absolute -bottom-1 -right-1 w-3 h-3 bg-success rounded-full border-2 border-neutral-700" />
             </div>
           </div>
         </header>

--- a/frontend/src/components/PopularConversions.tsx
+++ b/frontend/src/components/PopularConversions.tsx
@@ -78,9 +78,9 @@ const popularData: Record<FileCategory, CategoryInfo> = {
 const displayCategories: FileCategory[] = ['ebook', 'audio', 'video', 'image', 'document', 'archive', 'presentation'];
 
 const ConversionButton: React.FC<{from: string, to: string}> = ({ from, to }) => (
-    <button className="w-full flex items-center justify-between p-4 bg-white border border-slate-300 rounded-lg hover:border-blue-500 hover:shadow-md transition-all duration-200 group">
-        <span className="font-semibold text-slate-700">{from} a {to}</span>
-        <IconArrowRight className="w-5 h-5 text-slate-400 group-hover:text-blue-500 transition-colors" />
+    <button className="w-full flex items-center justify-between p-4 bg-white border border-neutral-200 rounded-lg hover:border-blue-500 hover:shadow-md transition-all duration-200 group">
+        <span className="font-semibold text-neutral-700">{from} a {to}</span>
+        <IconArrowRight className="w-5 h-5 text-neutral-600 group-hover:text-blue-500 transition-colors" />
     </button>
 );
 
@@ -92,7 +92,7 @@ export const PopularConversions: React.FC = () => {
 
     return (
         <section className="w-full max-w-6xl mx-auto py-16 sm:py-24">
-            <h2 className="text-3xl sm:text-4xl font-bold text-slate-800 tracking-tight text-center mb-12">
+            <h2 className="text-3xl sm:text-4xl font-bold text-neutral-900 tracking-tight text-center mb-12">
                 Accede rápidamente a nuestras solicitudes de conversión más populares
             </h2>
             <div className="flex flex-col md:flex-row gap-8 lg:gap-12">
@@ -106,7 +106,7 @@ export const PopularConversions: React.FC = () => {
                                 <li key={catKey}>
                                     <button 
                                         onClick={() => setActiveCategory(catKey as FileCategory)}
-                                        className={`w-full flex items-center space-x-3 p-3 rounded-lg text-left transition-colors text-lg ${isActive ? 'bg-blue-100 text-blue-700 font-semibold' : 'text-slate-600 hover:bg-slate-100'}`}
+                                        className={`w-full flex items-center space-x-3 p-3 rounded-lg text-left transition-colors text-lg ${isActive ? 'bg-blue-100 text-blue-700 font-semibold' : 'text-neutral-700 hover:bg-neutral-100'}`}
                                     >
                                         <Icon className="w-6 h-6 flex-shrink-0" />
                                         <span>{category.name}</span>

--- a/frontend/src/components/PricingSelector.tsx
+++ b/frontend/src/components/PricingSelector.tsx
@@ -138,14 +138,14 @@ export const PricingSelector: React.FC = () => {
         <div className="flex flex-col sm:flex-row items-center justify-center gap-6 mb-8">
           {/* Currency Selector */}
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-700">Moneda:</span>
-            <div className="flex bg-gray-100 rounded-lg p-1">
+            <span className="text-sm font-medium text-neutral-700">Moneda:</span>
+            <div className="flex bg-neutral-200 rounded-lg p-1">
               <button
                 onClick={() => setCurrency('eur')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   currency === 'eur'
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                    : 'text-neutral-700 hover:text-neutral-900'
                 }`}
               >
                 EUR (€)
@@ -155,7 +155,7 @@ export const PricingSelector: React.FC = () => {
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   currency === 'usd'
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                    : 'text-neutral-700 hover:text-neutral-900'
                 }`}
               >
                 USD ($)
@@ -165,14 +165,14 @@ export const PricingSelector: React.FC = () => {
 
           {/* Billing Cycle Toggle */}
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-700">Facturación:</span>
-            <div className="flex bg-gray-100 rounded-lg p-1">
+            <span className="text-sm font-medium text-neutral-700">Facturación:</span>
+            <div className="flex bg-neutral-200 rounded-lg p-1">
               <button
                 onClick={() => setBillingCycle('monthly')}
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   billingCycle === 'monthly'
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                    : 'text-neutral-700 hover:text-neutral-900'
                 }`}
               >
                 Mensual
@@ -182,7 +182,7 @@ export const PricingSelector: React.FC = () => {
                 className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                   billingCycle === 'annual'
                     ? 'bg-blue-600 text-white'
-                    : 'text-gray-600 hover:text-gray-900'
+                    : 'text-neutral-700 hover:text-neutral-900'
                 }`}
               >
                 Anual
@@ -196,13 +196,13 @@ export const PricingSelector: React.FC = () => {
 
         {/* Plans vs Credits Toggle */}
         <div className="flex justify-center mb-8">
-          <div className="flex bg-gray-100 rounded-lg p-1">
+          <div className="flex bg-neutral-200 rounded-lg p-1">
             <button
               onClick={() => setShowCredits(false)}
               className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
                 !showCredits
                   ? 'bg-blue-600 text-white'
-                  : 'text-gray-600 hover:text-gray-900'
+                  : 'text-neutral-700 hover:text-neutral-900'
               }`}
             >
               Planes de Suscripción
@@ -212,7 +212,7 @@ export const PricingSelector: React.FC = () => {
               className={`px-6 py-2 rounded-md text-sm font-medium transition-colors ${
                 showCredits
                   ? 'bg-blue-600 text-white'
-                  : 'text-gray-600 hover:text-gray-900'
+                  : 'text-neutral-700 hover:text-neutral-900'
               }`}
             >
               Paquetes de Créditos
@@ -230,7 +230,7 @@ export const PricingSelector: React.FC = () => {
               className={`relative pricing-card card-unified shadow-lg border-2 transition-all hover:shadow-xl ${
                 plan.popular
                   ? 'border-blue-500 ring-2 ring-blue-200'
-                  : 'border-slate-600/30'
+                  : 'border-neutral-700/30'
               }`}
             >
               {plan.popular && (
@@ -243,18 +243,18 @@ export const PricingSelector: React.FC = () => {
 
               <div className="p-6">
                 <div className="text-center mb-6">
-                  <h3 className="text-xl font-bold text-gray-900 mb-2">
+                  <h3 className="text-xl font-bold text-neutral-900 mb-2">
                     {plan.name}
                   </h3>
-                  <p className="text-gray-600 text-sm mb-4">
+                  <p className="text-neutral-700 text-sm mb-4">
                     {plan.description}
                   </p>
                   
                   <div className="mb-4">
-                    <div className="text-4xl font-bold text-gray-900">
+                    <div className="text-4xl font-bold text-neutral-900">
                       {formatPrice(getPrice(plan), currency)}
                     </div>
-                    <div className="text-gray-600 text-sm">
+                    <div className="text-neutral-700 text-sm">
                       {plan.id !== 'free' && `por ${billingCycle === 'monthly' ? 'mes' : 'mes (anual)'}`}
                     </div>
                     {billingCycle === 'annual' && plan.id !== 'free' && (
@@ -265,7 +265,7 @@ export const PricingSelector: React.FC = () => {
                   </div>
 
                   <div className="text-center mb-4">
-                    <span className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full text-sm font-medium">
+                    <span className="bg-neutral-200 text-neutral-900 px-3 py-1 rounded-full text-sm font-medium">
                       {plan.credits.toLocaleString()} créditos/mes
                     </span>
                   </div>
@@ -285,7 +285,7 @@ export const PricingSelector: React.FC = () => {
                           clipRule="evenodd"
                         />
                       </svg>
-                      <span className="text-gray-700 text-sm">{feature}</span>
+                      <span className="text-neutral-700 text-sm">{feature}</span>
                     </li>
                   ))}
                 </ul>
@@ -295,8 +295,8 @@ export const PricingSelector: React.FC = () => {
                     plan.popular
                       ? 'bg-blue-600 text-white hover:bg-blue-700'
                       : plan.enterprise
-                      ? 'bg-gray-900 text-white hover:bg-gray-800'
-                      : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
+                      ? 'bg-neutral-900 text-white hover:bg-neutral-800'
+                      : 'bg-neutral-200 text-neutral-900 hover:bg-neutral-300'
                   }`}
                 >
                   {plan.id === 'free' ? 'Comenzar Gratis' : 
@@ -324,7 +324,7 @@ export const PricingSelector: React.FC = () => {
                   {formatPrice(currency === 'eur' ? pkg.eur : pkg.usd, currency)}
                 </div>
                 
-                <div className="text-gray-500 text-sm mb-4">
+                <div className="text-neutral-600 text-sm mb-4">
                   {formatPrice((currency === 'eur' ? pkg.eur : pkg.usd) / pkg.credits, currency)}/crédito
                 </div>
 
@@ -345,7 +345,7 @@ export const PricingSelector: React.FC = () => {
 
       {/* Features Comparison */}
       <div className="mt-16 text-center">
-        <h3 className="text-2xl font-bold text-gray-900 mb-4">
+        <h3 className="text-2xl font-bold text-neutral-900 mb-4">
           Características de los Créditos
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -355,8 +355,8 @@ export const PricingSelector: React.FC = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
             </div>
-            <h4 className="font-semibold text-gray-900 mb-2">Sin Expiración</h4>
-            <p className="text-gray-600 text-sm text-center">Los créditos nunca caducan</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">Sin Expiración</h4>
+            <p className="text-neutral-700 text-sm text-center">Los créditos nunca caducan</p>
           </div>
           
           <div className="flex flex-col items-center p-4">
@@ -365,8 +365,8 @@ export const PricingSelector: React.FC = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
               </svg>
             </div>
-            <h4 className="font-semibold text-gray-900 mb-2">Transferibles</h4>
-            <p className="text-gray-600 text-sm text-center">Comparte entre cuentas del mismo dominio</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">Transferibles</h4>
+            <p className="text-neutral-700 text-sm text-center">Comparte entre cuentas del mismo dominio</p>
           </div>
           
           <div className="flex flex-col items-center p-4">
@@ -375,8 +375,8 @@ export const PricingSelector: React.FC = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
             </div>
-            <h4 className="font-semibold text-gray-900 mb-2">Transparentes</h4>
-            <p className="text-gray-600 text-sm text-center">Coste exacto mostrado antes de conversión</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">Transparentes</h4>
+            <p className="text-neutral-700 text-sm text-center">Coste exacto mostrado antes de conversión</p>
           </div>
           
           <div className="flex flex-col items-center p-4">
@@ -385,33 +385,33 @@ export const PricingSelector: React.FC = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
               </svg>
             </div>
-            <h4 className="font-semibold text-gray-900 mb-2">Flexibles</h4>
-            <p className="text-gray-600 text-sm text-center">Usa solo lo que necesitas</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">Flexibles</h4>
+            <p className="text-neutral-700 text-sm text-center">Usa solo lo que necesitas</p>
           </div>
         </div>
       </div>
 
       {/* FAQ Section */}
-      <div className="mt-16 bg-gray-50 rounded-2xl p-8">
-        <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
+      <div className="mt-16 bg-neutral-100 rounded-2xl p-8">
+        <h3 className="text-2xl font-bold text-neutral-900 mb-6 text-center">
           Preguntas Frecuentes
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <h4 className="font-semibold text-gray-900 mb-2">¿Puedo cambiar de plan en cualquier momento?</h4>
-            <p className="text-gray-600 text-sm">Sí, puedes actualizar o degradar tu plan en cualquier momento. Los cambios se aplican inmediatamente.</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">¿Puedo cambiar de plan en cualquier momento?</h4>
+            <p className="text-neutral-700 text-sm">Sí, puedes actualizar o degradar tu plan en cualquier momento. Los cambios se aplican inmediatamente.</p>
           </div>
           <div>
-            <h4 className="font-semibold text-gray-900 mb-2">¿Qué sucede si no uso todos mis créditos?</h4>
-            <p className="text-gray-600 text-sm">Los créditos no utilizados se acumulan al mes siguiente. Nunca pierdes créditos pagados.</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">¿Qué sucede si no uso todos mis créditos?</h4>
+            <p className="text-neutral-700 text-sm">Los créditos no utilizados se acumulan al mes siguiente. Nunca pierdes créditos pagados.</p>
           </div>
           <div>
-            <h4 className="font-semibold text-gray-900 mb-2">¿Puedo comprar créditos adicionales?</h4>
-            <p className="text-gray-600 text-sm">Sí, puedes comprar paquetes de créditos adicionales en cualquier momento con descuentos por volumen.</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">¿Puedo comprar créditos adicionales?</h4>
+            <p className="text-neutral-700 text-sm">Sí, puedes comprar paquetes de créditos adicionales en cualquier momento con descuentos por volumen.</p>
           </div>
           <div>
-            <h4 className="font-semibold text-gray-900 mb-2">¿Hay descuentos para facturación anual?</h4>
-            <p className="text-gray-600 text-sm">Sí, obtienes hasta 15% de descuento al pagar anualmente en lugar de mensualmente.</p>
+            <h4 className="font-semibold text-neutral-900 mb-2">¿Hay descuentos para facturación anual?</h4>
+            <p className="text-neutral-700 text-sm">Sí, obtienes hasta 15% de descuento al pagar anualmente en lugar de mensualmente.</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/TextToDocConverter.tsx
+++ b/frontend/src/components/TextToDocConverter.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 export const TextToDocConverter: React.FC = () => (
   <div className="p-4">
     <h2 className="text-xl font-semibold">Text to Document Converter</h2>
-    <p className="text-slate-600">Paste some text and receive a downloadable document.</p>
+    <p className="text-neutral-700">Paste some text and receive a downloadable document.</p>
   </div>
 );
 

--- a/frontend/src/components/UniversalConverter.tsx
+++ b/frontend/src/components/UniversalConverter.tsx
@@ -16,12 +16,12 @@ const ConversionStep: React.FC<{
           ? 'bg-success text-white' 
           : isActive 
             ? 'bg-primary text-white' 
-            : 'bg-gray-700 text-gray-400'
+            : 'bg-neutral-700 text-neutral-600'
       }`}
     >
       {number}
     </div>
-    <div className={`h-1 w-24 ${isCompleted ? 'bg-success' : 'bg-gray-700'}`}></div>
+    <div className={`h-1 w-24 ${isCompleted ? 'bg-success' : 'bg-neutral-700'}`}></div>
   </div>
 );
 
@@ -33,8 +33,8 @@ const ConversionCard: React.FC<{
   isActive: boolean;
   isCompleted?: boolean;
 }> = ({ icon, title, children, isActive, isCompleted }) => (
-  <div className={`bg-gray-800/80 rounded-lg p-5 transition-all ${
-    isActive ? 'border-2 border-primary shadow-lg' : 'border border-gray-700/50'
+  <div className={`bg-neutral-800/80 rounded-lg p-5 transition-all ${
+    isActive ? 'border-2 border-primary shadow-lg' : 'border border-neutral-700/50'
   }`}>
     <div className="flex items-center mb-3">
       <div className="text-3xl mr-3">{icon}</div>
@@ -58,14 +58,14 @@ const PopularConversion: React.FC<{
   onClick: () => void;
 }> = ({ from, to, icon, cost, onClick }) => (
   <div 
-    className="bg-gray-800/80 rounded-lg p-4 cursor-pointer hover:bg-gray-700/80 transition-all"
+    className="bg-neutral-800/80 rounded-lg p-4 cursor-pointer hover:bg-neutral-700/80 transition-all"
     onClick={onClick}
   >
     <div className="flex items-center justify-between">
       <div className="text-3xl mr-3">{icon}</div>
       <div className="flex-1">
         <h4 className="font-medium">{from} → {to}</h4>
-        <p className="text-xs text-gray-400">{cost} créditos</p>
+        <p className="text-xs text-neutral-600">{cost} créditos</p>
       </div>
     </div>
   </div>
@@ -139,7 +139,7 @@ export const UniversalConverter: React.FC = () => {
           <div className="text-3xl mr-3">🎯</div>
           <h1 className="text-3xl font-bold">Conversor Inteligente</h1>
         </div>
-        <p className="text-gray-300">Convierte archivos con inteligencia artificial avanzada</p>
+        <p className="text-neutral-200">Convierte archivos con inteligencia artificial avanzada</p>
       </div>
 
       {/* Pasos de conversión */}
@@ -164,9 +164,9 @@ export const UniversalConverter: React.FC = () => {
               onDrop={handleDrop}
               onDragOver={(e) => e.preventDefault()}
               onClick={() => fileInputRef.current?.click()}
-              className="border-2 border-dashed border-gray-600 rounded-lg p-4 text-center cursor-pointer hover:border-primary transition-colors"
+              className="border-2 border-dashed border-neutral-700 rounded-lg p-4 text-center cursor-pointer hover:border-primary transition-colors"
             >
-              <p className="text-gray-300 text-sm mb-2">
+              <p className="text-neutral-200 text-sm mb-2">
                 Arrastra tu archivo aquí<br />o haz clic para seleccionar
               </p>
               <input
@@ -178,9 +178,9 @@ export const UniversalConverter: React.FC = () => {
             </div>
           ) : (
             <div className="text-sm">
-              <p className="text-gray-400">Archivo seleccionado:</p>
+              <p className="text-neutral-600">Archivo seleccionado:</p>
               <p className="font-medium truncate">{selectedFile?.name}</p>
-              <p className="text-xs text-gray-500">{selectedFile && formatFileSize(selectedFile.size)}</p>
+              <p className="text-xs text-neutral-600">{selectedFile && formatFileSize(selectedFile.size)}</p>
             </div>
           )}
         </ConversionCard>
@@ -195,17 +195,17 @@ export const UniversalConverter: React.FC = () => {
           {currentStep === 2 ? (
             <div className="text-center py-2">
               <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full mx-auto mb-2"></div>
-              <p className="text-gray-300 text-sm">Analizando archivo...</p>
+              <p className="text-neutral-200 text-sm">Analizando archivo...</p>
             </div>
           ) : currentStep > 2 ? (
             <div className="text-sm">
-              <p className="text-gray-400">Análisis completado</p>
+              <p className="text-neutral-600">Análisis completado</p>
               <div className="mt-2 bg-success/10 text-success text-xs p-2 rounded">
                 ✓ Archivo analizado correctamente
               </div>
             </div>
           ) : (
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-neutral-600">
               Esperando archivo...
             </div>
           )}
@@ -220,11 +220,11 @@ export const UniversalConverter: React.FC = () => {
         >
           {currentStep >= 3 ? (
             <div>
-              <label className="block text-sm text-gray-400 mb-1">Formato de salida</label>
+              <label className="block text-sm text-neutral-600 mb-1">Formato de salida</label>
               <select
                 value={targetFormat}
                 onChange={(e) => setTargetFormat(e.target.value)}
-                className="w-full bg-gray-700 border border-gray-600 rounded-md p-2 text-white"
+                className="w-full bg-neutral-700 border border-neutral-700 rounded-md p-2 text-white"
                 disabled={currentStep > 3}
               >
                 <option value="">Seleccionar formato</option>
@@ -236,7 +236,7 @@ export const UniversalConverter: React.FC = () => {
               
               {targetFormat && currentStep === 3 && (
                 <div className="mt-3">
-                  <p className="text-xs text-gray-400 mb-2">Costo: 0 créditos</p>
+                  <p className="text-xs text-neutral-600 mb-2">Costo: 0 créditos</p>
                   <button
                     onClick={handleConvert}
                     className="w-full bg-primary hover:bg-primary-dark text-white py-2 rounded-md transition-colors"
@@ -247,7 +247,7 @@ export const UniversalConverter: React.FC = () => {
               )}
             </div>
           ) : (
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-neutral-600">
               Esperando análisis...
             </div>
           )}
@@ -264,7 +264,7 @@ export const UniversalConverter: React.FC = () => {
             isConverting ? (
               <div className="text-center py-2">
                 <div className="animate-pulse w-8 h-8 bg-primary rounded-full mx-auto mb-2"></div>
-                <p className="text-gray-300 text-sm">Procesando...</p>
+                <p className="text-neutral-200 text-sm">Procesando...</p>
               </div>
             ) : (
               <div className="text-center">
@@ -274,13 +274,13 @@ export const UniversalConverter: React.FC = () => {
                 <button className="bg-success hover:bg-success/80 text-white py-2 px-4 rounded-md transition-colors">
                   Descargar Archivo
                 </button>
-                <p className="text-xs text-gray-400 mt-2">
+                <p className="text-xs text-neutral-600 mt-2">
                   Descarga pendiente
                 </p>
               </div>
             )
           ) : (
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-neutral-600">
               Esperando conversión...
             </div>
           )}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -14,7 +14,7 @@ export const UserMenu: React.FC = () => {
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center space-x-3 bg-slate-700/50 rounded-lg px-3 py-2 hover:bg-slate-600/50 transition-colors"
+        className="flex items-center space-x-3 bg-neutral-700/50 rounded-lg px-3 py-2 hover:bg-neutral-700/50 transition-colors"
       >
         <div className="flex items-center space-x-2">
           <span className="text-cyan-400">💎</span>
@@ -23,20 +23,20 @@ export const UserMenu: React.FC = () => {
         <div className="w-8 h-8 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
           <span className="text-white text-sm">{userInfo.avatar}</span>
         </div>
-        <span className="text-slate-300 text-sm">▼</span>
+        <span className="text-neutral-200 text-sm">▼</span>
       </button>
 
       {isOpen && (
         <div className="user-menu dropdown-unified w-80 shadow-xl">
           {/* User Info Header */}
-          <div className="p-4 border-b border-slate-700/50">
+          <div className="p-4 border-b border-neutral-700/50">
             <div className="flex items-center space-x-3">
               <div className="w-12 h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center">
                 <span className="text-white text-lg">{userInfo.avatar}</span>
               </div>
               <div>
                 <h3 className="text-white font-medium">{userInfo.name}</h3>
-                <p className="text-slate-400 text-sm">{userInfo.email}</p>
+                <p className="text-neutral-600 text-sm">{userInfo.email}</p>
                 <span className="inline-block px-2 py-1 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs rounded-full mt-1">
                   Plan {userInfo.plan}
                 </span>
@@ -45,46 +45,46 @@ export const UserMenu: React.FC = () => {
           </div>
 
           {/* Credits & Usage */}
-          <div className="p-4 border-b border-slate-700/50">
-            <h4 className="text-slate-300 font-medium mb-3">Tu Actividad</h4>
+          <div className="p-4 border-b border-neutral-700/50">
+            <h4 className="text-neutral-200 font-medium mb-3">Tu Actividad</h4>
             <div className="space-y-2">
               <div className="flex justify-between items-center">
-                <span className="text-slate-400 text-sm">Créditos disponibles</span>
+                <span className="text-neutral-600 text-sm">Créditos disponibles</span>
                 <span className="text-cyan-400 font-medium">50</span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-slate-400 text-sm">Conversiones hoy</span>
+                <span className="text-neutral-600 text-sm">Conversiones hoy</span>
                 <span className="text-green-400 font-medium">47</span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="text-slate-400 text-sm">Créditos usados</span>
+                <span className="text-neutral-600 text-sm">Créditos usados</span>
                 <span className="text-orange-400 font-medium">156</span>
               </div>
-              <div className="w-full bg-slate-700 rounded-full h-2 mt-3">
+              <div className="w-full bg-neutral-700 rounded-full h-2 mt-3">
                 <div className="bg-gradient-to-r from-blue-500 to-cyan-500 h-2 rounded-full" style={{width: '68%'}}></div>
               </div>
-              <p className="text-slate-400 text-xs">68% del límite mensual usado</p>
+              <p className="text-neutral-600 text-xs">68% del límite mensual usado</p>
             </div>
           </div>
 
           {/* Quick Actions */}
-          <div className="p-4 border-b border-slate-700/50">
-            <h4 className="text-slate-300 font-medium mb-3">Acciones Rápidas</h4>
+          <div className="p-4 border-b border-neutral-700/50">
+            <h4 className="text-neutral-200 font-medium mb-3">Acciones Rápidas</h4>
             <div className="space-y-2">
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
                 <span className="text-blue-400">💳</span>
                 <span className="text-white text-sm">Comprar más créditos</span>
               </button>
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
                 <span className="text-purple-400">⬆️</span>
                 <span className="text-white text-sm">Actualizar plan</span>
               </button>
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
                 <span className="text-green-400">📊</span>
                 <span className="text-white text-sm">Ver estadísticas</span>
               </button>
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
-                <span className="text-slate-400">⚙️</span>
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
+                <span className="text-neutral-600">⚙️</span>
                 <span className="text-white text-sm">Configuración</span>
               </button>
             </div>
@@ -93,19 +93,19 @@ export const UserMenu: React.FC = () => {
           {/* Account Actions */}
           <div className="p-4">
             <div className="space-y-2">
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
-                <span className="text-slate-400">👤</span>
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
+                <span className="text-neutral-600">👤</span>
                 <span className="text-white text-sm">Editar perfil</span>
               </button>
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
-                <span className="text-slate-400">🔒</span>
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
+                <span className="text-neutral-600">🔒</span>
                 <span className="text-white text-sm">Privacidad y seguridad</span>
               </button>
-              <button className="w-full flex items-center space-x-3 p-2 hover:bg-slate-700/50 rounded-lg transition-colors">
-                <span className="text-slate-400">❓</span>
+              <button className="w-full flex items-center space-x-3 p-2 hover:bg-neutral-700/50 rounded-lg transition-colors">
+                <span className="text-neutral-600">❓</span>
                 <span className="text-white text-sm">Ayuda y soporte</span>
               </button>
-              <hr className="border-slate-700/50 my-2" />
+              <hr className="border-neutral-700/50 my-2" />
               <button className="w-full flex items-center space-x-3 p-2 hover:bg-red-500/20 rounded-lg transition-colors">
                 <span className="text-red-400">🚪</span>
                 <span className="text-red-400 text-sm">Cerrar sesión</span>

--- a/frontend/src/components/VideoConverter.tsx
+++ b/frontend/src/components/VideoConverter.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 export const VideoConverter: React.FC = () => (
   <div className="p-4">
     <h2 className="text-xl font-semibold">Video Converter</h2>
-    <p className="text-slate-600">Convert your video files into different formats here.</p>
+    <p className="text-neutral-700">Convert your video files into different formats here.</p>
   </div>
 );
 

--- a/frontend/src/styles/brand-styles.css
+++ b/frontend/src/styles/brand-styles.css
@@ -1,5 +1,5 @@
 /* frontend/src/styles/variables.css */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.apple.com/sf-pro-display.css');
 
 :root {
   /* Colores primarios */
@@ -16,12 +16,13 @@
   --color-danger: #DC3545;
   
   /* Colores neutros */
-  --color-white: #FFFFFF;
-  --color-gray-100: #F5F7FA;
-  --color-gray-200: #E4E7EB;
-  --color-gray-400: #8492A6;
-  --color-gray-700: #3E4C59;
-  --color-gray-900: #1F2933;
+  --color-neutral-100: #FFFFFF;
+  --color-neutral-200: #F5F5F5;
+  --color-neutral-300: #E4E7EB;
+  --color-neutral-400: #8492A6;
+  --color-neutral-700: #3E4C59;
+  --color-neutral-800: #1F2933;
+  --color-neutral-900: #0D0D0D;
   
   /* Tamaños de fuente - Escritorio */
   --font-size-h1: 2rem;        /* 32px */
@@ -46,18 +47,34 @@
   --line-height-relaxed: 1.5;
   
   /* Espaciado */
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 24px;
-  --space-6: 32px;
-  --space-7: 48px;
+  --space-1: 8px;
+  --space-2: 16px;
+  --space-3: 24px;
+  --space-4: 32px;
+  --space-5: 40px;
+  --space-6: 48px;
+  --space-7: 56px;
   --space-8: 64px;
   
-  /* Fuente principal */
-  --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  /* Fuentes */
+  --font-heading: 'SF Pro Display', -apple-system, sans-serif;
+  --font-body: 'SF Pro Display', -apple-system, sans-serif;
 }
+
+/* Utilidades de color */
+.bg-neutral-900 { background-color: var(--color-neutral-900); }
+.bg-neutral-800 { background-color: var(--color-neutral-800); }
+.bg-neutral-700 { background-color: var(--color-neutral-700); }
+.bg-neutral-300 { background-color: var(--color-neutral-300); }
+.bg-neutral-200 { background-color: var(--color-neutral-200); }
+.bg-neutral-100 { background-color: var(--color-neutral-100); }
+.text-neutral-900 { color: var(--color-neutral-900); }
+.text-neutral-700 { color: var(--color-neutral-700); }
+.text-neutral-600 { color: var(--color-neutral-400); }
+.text-neutral-200 { color: var(--color-neutral-200); }
+.text-neutral-100 { color: var(--color-neutral-100); }
+.border-neutral-700 { border-color: var(--color-neutral-700); }
+.border-neutral-200 { border-color: var(--color-neutral-200); }
 
 /* Media query para móviles */
 @media (max-width: 768px) {
@@ -72,7 +89,7 @@
 
 /* Componentes base */
 .card {
-  background-color: var(--color-gray-800, rgba(31, 41, 55, 0.5));
+  background-color: var(--color-neutral-800, rgba(31, 41, 55, 0.5));
   backdrop-filter: blur(8px);
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
@@ -82,7 +99,7 @@
 
 .card-header {
   padding: var(--space-4);
-  border-bottom: 1px solid var(--color-gray-700, rgba(62, 76, 89, 0.5));
+  border-bottom: 1px solid var(--color-neutral-700, rgba(62, 76, 89, 0.5));
 }
 
 .card-body {
@@ -91,8 +108,8 @@
 
 .card-footer {
   padding: var(--space-4);
-  border-top: 1px solid var(--color-gray-700, rgba(62, 76, 89, 0.5));
-  background-color: var(--color-gray-800, rgba(31, 41, 55, 0.3));
+  border-top: 1px solid var(--color-neutral-700, rgba(62, 76, 89, 0.5));
+  background-color: var(--color-neutral-800, rgba(31, 41, 55, 0.3));
 }
 
 /* Botones */
@@ -111,7 +128,7 @@
 
 .btn-primary {
   background-color: var(--color-primary);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .btn-primary:hover {
@@ -130,7 +147,7 @@
 
 .btn-danger {
   background-color: var(--color-danger);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .btn-danger:hover {
@@ -139,7 +156,7 @@
 
 .btn-success {
   background-color: var(--color-success);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .btn-success:hover {
@@ -162,23 +179,23 @@
   margin-bottom: var(--space-2);
   font-size: var(--font-size-small);
   font-weight: var(--font-weight-medium);
-  color: var(--color-gray-400);
+  color: var(--color-neutral-400);
 }
 
 .input {
   width: 100%;
   padding: var(--space-3);
-  border: 1px solid var(--color-gray-700);
+  border: 1px solid var(--color-neutral-700);
   border-radius: 6px;
   font-size: var(--font-size-body);
   line-height: var(--line-height-normal);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
   background-color: rgba(31, 41, 55, 0.3);
   transition: all 0.2s ease;
 }
 
 .input:hover {
-  border-color: var(--color-gray-400);
+  border-color: var(--color-neutral-400);
 }
 
 .input:focus {
@@ -269,9 +286,9 @@
 
 /* Estilos generales */
 body {
-  font-family: var(--font-primary);
-  color: var(--color-white);
-  background-color: var(--color-gray-900);
+  font-family: var(--font-body);
+  color: var(--color-neutral-100);
+  background-color: var(--color-neutral-900);
 }
 
 /* Estilos específicos para el conversor */
@@ -289,24 +306,24 @@ body {
 
 .conversion-step.active {
   background-color: var(--color-primary);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
   box-shadow: 0 0 0 4px rgba(0, 110, 230, 0.2);
 }
 
 .conversion-step.completed {
   background-color: var(--color-success);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .conversion-step.inactive {
-  background-color: var(--color-gray-700);
-  color: var(--color-gray-400);
+  background-color: var(--color-neutral-700);
+  color: var(--color-neutral-400);
 }
 
 .step-connector {
   height: 2px;
   width: 64px;
-  background-color: var(--color-gray-700);
+  background-color: var(--color-neutral-700);
   transition: all 0.3s ease;
 }
 
@@ -332,7 +349,7 @@ body {
 }
 
 .file-upload-area {
-  border: 2px dashed var(--color-gray-600);
+  border: 2px dashed var(--color-neutral-600);
   border-radius: 8px;
   padding: 24px;
   text-align: center;
@@ -373,12 +390,12 @@ body {
 
 .sidebar-nav-item.active {
   background-color: rgba(0, 110, 230, 0.1);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .sidebar-nav-item:hover:not(.active) {
   background-color: rgba(62, 76, 89, 0.3);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .sidebar-nav-icon {
@@ -401,12 +418,12 @@ body {
 
 .sidebar-badge.pro {
   background-color: var(--color-primary);
-  color: var(--color-white);
+  color: var(--color-neutral-100);
 }
 
 .sidebar-badge.count {
-  background-color: var(--color-gray-700);
-  color: var(--color-white);
+  background-color: var(--color-neutral-700);
+  color: var(--color-neutral-100);
 }
 
 /* Animaciones */


### PR DESCRIPTION
## Summary
- update brand-styles variables to match design guide
- add color utility classes for new CSS variables
- switch components to use neutral classes instead of hardcoded Tailwind colors

## Testing
- `npx vitest run` *(fails: Cannot find package '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_688245cf09a88320b089a5a23be6bbfc