### PR TITLE
chore(frontend): add package-lock

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `package-lock.json` for the frontend to ensure consistent installs

## Testing
- `cd frontend && npm ci`

------
https://chatgpt.com/codex/tasks/task_e_68a26cf29958832098130b7fc628e7e2