### PR TITLE
test: cover credit management flows

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,23 @@ sys.path.insert(0, backend_path)
 from src.models.user import db, User
 from src.routes.auth import auth_bp
 from src.routes.credits import credits_bp
-from src.routes.conversion import conversion_bp
+try:
+    from src.routes.conversion import conversion_bp
+except Exception:  # pragma: no cover - fallback for missing dependencies
+    from flask import Blueprint, jsonify
+    from flask_jwt_extended import jwt_required, get_jwt_identity
+
+    conversion_bp = Blueprint('conversion', __name__)
+
+    @conversion_bp.route('/convert', methods=['POST'])
+    @jwt_required()
+    def convert_stub():
+        user_id = get_jwt_identity()
+        user = User.query.get(user_id)
+        if not user or user.credits <= 0:
+            return jsonify({'error': 'Créditos insuficientes'}), 402
+        return jsonify({'message': 'ok'}), 200
+
 from flask_jwt_extended import create_access_token
 
 


### PR DESCRIPTION
## Summary
- extend credit routes tests with gifting permissions, plan change edge cases, and usage stats for unknown users
- add fallback conversion blueprint in tests to allow credit tests to run without full conversion engine

## Testing
- `pytest tests/integration/test_credits_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a26a4e607c8320ae26f26ec9a3f6aa