### PR TITLE
chore: remove temporary and compiled artifacts

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,3 +5,7 @@ out
 
 # Variables de entorno locales del frontend
 .env.local
+
+# Compilación y caché
+**/__pycache__/
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- remove stale frontend backup artifacts
- ignore Python cache directories and TypeScript build info

## Testing
- `pytest tests` *(fails: cannot import name 'validate_and_classify' from 'src.models.conversion')*

------
https://chatgpt.com/codex/tasks/task_e_68a26a1b83308320aca71c7c298d61b9