### PR TITLE
fix: secure CORS and debug configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Antes de ejecutar el backend, configura las siguientes variables de entorno:
 
 - `SECRET_KEY`: clave usada por Flask para sesiones.
 - `JWT_SECRET_KEY`: clave para firmar tokens JWT.
-- `CORS_ORIGINS`: lista separada por comas de orígenes permitidos para CORS (ej. `http://localhost:3000,http://localhost:5173`).
+- `ALLOWED_ORIGINS`: lista separada por comas de orígenes permitidos para CORS (ej. `http://localhost:3000,http://localhost:5173`). El comodín `*` se ignora por seguridad.
 - `FLASK_DEBUG`: establece `true` para habilitar el modo debug (opcional).
 
 ### Ejecutar Tests

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -27,14 +27,24 @@ app.config['JWT_SECRET_KEY'] = jwt_secret_key
 app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(days=7)
 
 # Configuración de CORS para permitir requests del frontend
-allowed_origins = os.environ.get('CORS_ORIGINS')
+allowed_origins = os.environ.get('ALLOWED_ORIGINS')
 if not allowed_origins:
-    raise RuntimeError('CORS_ORIGINS must be set as environment variable')
-origins = [origin.strip() for origin in allowed_origins.split(',') if origin.strip()]
-CORS(app,
-     origins=origins,
-     supports_credentials=True,
-     allow_headers=['Content-Type', 'Authorization'])
+    raise RuntimeError('ALLOWED_ORIGINS must be set as environment variable')
+
+origins = [
+    origin.strip()
+    for origin in allowed_origins.split(',')
+    if origin.strip() and origin.strip() != '*'
+]
+if not origins:
+    raise RuntimeError('ALLOWED_ORIGINS must specify at least one origin without wildcard')
+
+CORS(
+    app,
+    origins=origins,
+    supports_credentials=True,
+    allow_headers=['Content-Type', 'Authorization']
+)
 
 # Inicializar SocketIO
 socketio.init_app(app, cors_allowed_origins=origins)
@@ -147,6 +157,6 @@ if __name__ == '__main__':
     print("🔍 Información del API: http://localhost:8000/api/info")
     print("❤️  Verificación de salud: http://localhost:8000/api/health")
     print("=" * 50)
-    debug_mode = os.environ.get('FLASK_DEBUG', 'false').lower() in ('1', 'true', 'yes')
+    debug_mode = os.environ.get('FLASK_DEBUG', '').lower() in ('1', 'true', 'yes')
     socketio.run(app, host='0.0.0.0', port=8000, debug=debug_mode)
 


### PR DESCRIPTION
## Summary
- read CORS origins from `ALLOWED_ORIGINS` environment variable and ignore wildcard
- toggle Flask debug mode based on `FLASK_DEBUG`
- document new environment variables

## Testing
- `pytest tests/unit tests/integration` *(fails: ImportError: cannot import name 'validate_and_classify' from 'src.models.conversion')*

------
https://chatgpt.com/codex/tasks/task_e_68a26a225d9483208ccbb7d5a70ce0b1