### PR TITLE
feat: add forgot password flow

### DIFF
--- a/backend/src/routes/auth.py
+++ b/backend/src/routes/auth.py
@@ -120,6 +120,21 @@ def login():
     except Exception as e:
         return jsonify({'error': f'Error interno del servidor: {str(e)}'}), 500
 
+
+@auth_bp.route('/forgot-password', methods=['POST'])
+def forgot_password():
+    """Inicia el proceso de recuperación de contraseña"""
+    try:
+        data = request.get_json() or {}
+        email = data.get('email')
+        if not email:
+            return jsonify({'error': 'Email requerido'}), 400
+
+        # Aquí se enviaría un correo electrónico real o un código temporal
+        return jsonify({'message': 'Se enviaron instrucciones de recuperación si el email existe'}), 200
+    except Exception as e:
+        return jsonify({'error': f'Error interno del servidor: {str(e)}'}), 500
+
 @auth_bp.route('/profile', methods=['GET'])
 @jwt_required()
 def get_profile():

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { AuthService } from '../services/authService';
-import { apiService } from '../services/api';
 
 interface LoginProps {
   onSuccess?: () => void;
@@ -77,17 +76,8 @@ export const Login: React.FC<LoginProps> = ({
     if (error) setError('');
   };
 
-  const handleForgotPassword = async () => {
-    if (!formData.email) {
-      setError('Por favor ingresa tu correo electrónico');
-      return;
-    }
-    try {
-      await apiService.requestPasswordReset(formData.email);
-      alert('Se ha enviado un enlace de recuperación a tu correo.');
-    } catch (e) {
-      setError('No se pudo iniciar la recuperación de contraseña');
-    }
+  const handleForgotPassword = () => {
+    window.location.assign('/forgot-password');
   };
 
     return (

--- a/frontend/src/components/__tests__/Login.test.tsx
+++ b/frontend/src/components/__tests__/Login.test.tsx
@@ -1,44 +1,26 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { Login } from '../Login';
-import { apiService } from '../../services/api';
 
 vi.mock('../../services/authService', () => ({
   AuthService: {
     getInstance: () => ({
       signIn: vi.fn(),
       signInWithGoogle: vi.fn(),
-      requestPasswordReset: vi.fn(),
     }),
   },
 }), { virtual: true });
-vi.mock('../../services/api', () => ({
-  apiService: {
-    requestPasswordReset: vi.fn().mockResolvedValue(undefined),
-  },
-}));
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 describe('Login forgot password flow', () => {
-  it('requests password reset when email provided', async () => {
-    window.alert = vi.fn();
-    render(<Login />);
-    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'user@example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: '¿Olvidaste tu contraseña?' }));
-    await waitFor(() => {
-      expect(apiService.requestPasswordReset).toHaveBeenCalledWith('user@example.com');
-    });
-  });
-
-  it('shows error when email is missing', async () => {
+  it('redirects to forgot password page', () => {
     render(<Login />);
     fireEvent.click(screen.getByRole('button', { name: '¿Olvidaste tu contraseña?' }));
-    expect(apiService.requestPasswordReset).not.toHaveBeenCalled();
-    expect(screen.getByText('Por favor ingresa tu correo electrónico')).toBeInTheDocument();
+    expect((window.location as any).assign).toHaveBeenCalledWith('/forgot-password');
   });
 });

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -19,3 +19,9 @@ class TestAuthRoutes:
         resp = client.post('/api/auth/login', json=login_data)
         assert resp.status_code == 200
         assert 'access_token' in resp.get_json()
+
+    def test_forgot_password(self, client):
+        """Debe iniciar el flujo de recuperación de contraseña"""
+        resp = client.post('/api/auth/forgot-password', json={'email': 'user@example.com'})
+        assert resp.status_code == 200
+        assert 'message' in resp.get_json()


### PR DESCRIPTION
## Summary
- redirect forgotten password requests to a new page from the login component
- stub backend endpoint for initiating password reset
- cover new flow with frontend and backend tests

## Testing
- `pytest tests/integration/test_auth_routes.py::TestAuthRoutes::test_forgot_password -q` *(fails: cannot import name 'validate_and_classify')*
- `npx -y vitest run frontend/src/components/__tests__/Login.test.tsx` *(fails: Cannot find package 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68a26a3de00883208710a5068a012a99