### PR TITLE
feat: add history view placeholder

### DIFF
--- a/frontend/src/components/HistoryView.tsx
+++ b/frontend/src/components/HistoryView.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+// TODO: Integrar con el backend para obtener el historial real de conversiones
+// TODO: Reemplazar el contenido estático con la información recibida de la API
+// TODO: Manejar estados de carga y error al solicitar los datos
+const HistoryView: React.FC = () => {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-h1 mb-4">Historial</h1>
+      <p>Próximamente se mostrará el historial de actividades.</p>
+    </div>
+  );
+};
+
+export default HistoryView;

--- a/frontend/src/components/Layout/Sidebar.tsx
+++ b/frontend/src/components/Layout/Sidebar.tsx
@@ -1,17 +1,20 @@
 import React, { useRef } from 'react';
-import { ChevronLeft, ChevronRight, Home, FileText, Settings, User, CreditCard } from 'lucide-react';
+import Link from 'next/link';
+import { ChevronLeft, ChevronRight, Home, FileText, Settings, User, CreditCard, History } from 'lucide-react';
 import AccessibleIcon from '../AccessibleIcon';
 
 interface SidebarProps {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
   isCollapsed: boolean;
   setIsCollapsed: (collapsed: boolean) => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
+const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, isCollapsed, setIsCollapsed }) => {
   // Ahora useRef está correctamente importado
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>, index: number) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       const nextIndex = (index + 1) % itemRefs.current.length;
@@ -26,6 +29,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
   const menuItems = [
     { icon: Home, label: 'Dashboard', path: '/' },
     { icon: FileText, label: 'Conversiones', path: '/conversions' },
+    { icon: History, label: 'Historial', path: '/history' },
     { icon: CreditCard, label: 'Créditos', path: '/credits' },
     { icon: User, label: 'Perfil', path: '/profile' },
     { icon: Settings, label: 'Configuración', path: '/settings' }
@@ -59,9 +63,11 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
         <ul className="space-y-2">
           {menuItems.map((item, index) => (
             <li key={item.path}>
-              <button
+              <Link
+                href={item.path}
                 ref={(el) => { itemRefs.current[index] = el; }}
                 onKeyDown={(e) => handleKeyDown(e, index)}
+                onClick={() => setActiveTab(item.label)}
                 className={`flex items-center w-full px-3 py-2 rounded-lg hover:bg-blue-50 hover:text-blue-600 transition-colors ${
                   isCollapsed ? 'justify-center' : 'justify-start'
                 }`}
@@ -70,7 +76,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
                   <item.icon size={20} />
                 </AccessibleIcon>
                 {!isCollapsed && <span className="ml-3">{item.label}</span>}
-              </button>
+              </Link>
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/history.tsx
+++ b/frontend/src/pages/history.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import HistoryView from '../components/HistoryView';
+import { MainLayout } from '../components/Layout/MainLayout';
+
+export default function HistoryPage() {
+  const [activeTab, setActiveTab] = useState('history');
+
+  return (
+    <MainLayout activeTab={activeTab} setActiveTab={setActiveTab}>
+      <HistoryView />
+    </MainLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add HistoryView component with placeholder text and TODOs for real data
- expose History page route and sidebar navigation link

## Testing
- `npm test -- --run` *(fails: FormatSelector tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a320b98ff08320a07207544bcd5384