### PR TITLE
feat: redirect after auth

### DIFF
--- a/frontend/src/auth/AuthContext.test.tsx
+++ b/frontend/src/auth/AuthContext.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../services/api', () => ({
+  apiService: {
+    login: vi.fn(),
+    register: vi.fn(),
+    verifyToken: vi.fn().mockResolvedValue({ valid: false, user: null }),
+    logout: vi.fn(),
+    clearToken: vi.fn(),
+    getProfile: vi.fn(),
+  }
+}));
+
+import { AuthProvider, useAuth } from './AuthContext';
+import { apiService } from '../services/api';
+import { MemoryRouter } from 'react-router-dom';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function TestComponent() {
+  const { login } = useAuth();
+  return (
+    <button onClick={() => login({ email: 'test@example.com', password: 'pass' })}>
+      Login
+    </button>
+  );
+}
+
+describe('AuthContext navigation', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('navigates to /app after successful login', async () => {
+    (apiService.login as any).mockResolvedValue({
+      user: { id: 1, email: 'test@example.com', full_name: 'Test' },
+      token: 'fake',
+    });
+
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Login'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/app');
+    });
+  });
+});

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 // frontend/src/auth/AuthContext.tsx
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { apiService, LoginData, RegisterData } from '../services/api';
 import type { User } from '../types/User';
 
@@ -32,8 +33,15 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
 
   const isAuthenticated = !!user;
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/app');
+    }
+  }, [isAuthenticated, navigate]);
 
   // Verificar autenticación al cargar la aplicación
   useEffect(() => {


### PR DESCRIPTION
## Summary
- redirect to /app once authenticated using useNavigate
- add AuthContext login navigation test for vitest

## Testing
- `npm test src/auth/AuthContext.test.tsx -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a320b6f47483209411166d14361c0c