### PR TITLE
feat: add interactive conversions section

### DIFF
--- a/frontend/src/components/InteractiveConversions.tsx
+++ b/frontend/src/components/InteractiveConversions.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { IconAudio, IconVideo, IconImage, IconFile, IconArchive, IconPresentation, IconEbook } from './Icons';
+
+interface Category {
+  key: string;
+  name: string;
+  icon: React.FC<{ className?: string }>;
+}
+
+const categories: Category[] = [
+  { key: 'document', name: 'Documentos', icon: IconFile },
+  { key: 'image', name: 'Imágenes', icon: IconImage },
+  { key: 'audio', name: 'Audio', icon: IconAudio },
+  { key: 'video', name: 'Video', icon: IconVideo },
+  { key: 'presentation', name: 'Presentaciones', icon: IconPresentation },
+  { key: 'ebook', name: 'Ebooks', icon: IconEbook },
+  { key: 'archive', name: 'Archivos', icon: IconArchive },
+];
+
+export const InteractiveConversions: React.FC = () => {
+  return (
+    <section className="w-full max-w-6xl mx-auto py-12 sm:py-16">
+      <h2 className="text-h2 text-center text-white mb-8">
+        ¿Qué quieres convertir hoy?
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        {categories.map(({ key, name, icon: Icon }) => (
+          <a
+            key={key}
+            href={`/app?category=${key}`}
+            className="flex flex-col items-center justify-center p-6 rounded-lg bg-slate-800/50 hover:bg-primary/20 transition-colors"        >
+            <Icon className="w-12 h-12 mb-4 text-secondary" />
+            <span className="text-white font-semibold">{name}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default InteractiveConversions;

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import Sidebar from './Sidebar';
 import { Header } from './Header';
 import { CreditProvider, CreditBalance, CreditHistory } from '@/components/CreditSystem';
+import { InteractiveConversions } from '@/components/InteractiveConversions';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -81,7 +82,10 @@ export const MainLayout: React.FC<MainLayoutProps> = ({
             </div>
           </CreditProvider>
         ) : (
-          <div className="p-6">{children}</div>
+          <div className="p-6 space-y-8">
+            {children}
+            <InteractiveConversions />
+          </div>
         )}
       </main>
     </div>

--- a/frontend/src/components/__tests__/InteractiveConversions.test.tsx
+++ b/frontend/src/components/__tests__/InteractiveConversions.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { InteractiveConversions } from '../InteractiveConversions';
+
+describe('InteractiveConversions', () => {
+  it('renders category links to /app', () => {
+    render(<InteractiveConversions />);
+    const link = screen.getByRole('link', { name: /Documentos/i });
+    expect(link).toHaveAttribute('href', '/app?category=document');
+  });
+});


### PR DESCRIPTION
## Summary
- add interactive conversions component with category links to `/app`
- show interactive conversions in main layout
- test interactive conversions links

## Testing
- `npm test` (fails: 7 failed, 11 passed)
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68a320b305ac8320aa9cebc63877749d