### PR TITLE
feat(frontend): add supported formats view

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -77,7 +77,7 @@ export const Footer: React.FC = () => {
                         <h5 className="font-bold mb-4">Acerca de</h5>
                         <ul className="space-y-3">
                             <FooterLink href="#">Precios</FooterLink>
-                            <FooterLink href="#">Formatos Compatibles</FooterLink>
+                            <FooterLink href="/formats">Formatos Compatibles</FooterLink>
                             <FooterLink href="#">FAQ</FooterLink>
                         </ul>
                         <a href="#" className="mt-6 inline-block w-full text-center px-4 py-2 border border-white rounded-md hover:bg-white hover:text-slate-800 font-semibold transition-colors">

--- a/frontend/src/components/FormatsView.tsx
+++ b/frontend/src/components/FormatsView.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { apiService } from '../services/api';
+
+type SupportedResponse = {
+  supported_conversions: Record<string, Record<string, number>>;
+  allowed_extensions: string[];
+};
+
+const FormatsView: React.FC = () => {
+  const [data, setData] = useState<SupportedResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFormats = async () => {
+      try {
+        const res = await apiService.getSupportedFormats();
+        setData(res);
+      } catch (err: any) {
+        setError(err.message || 'Error cargando formatos');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFormats();
+  }, []);
+
+  if (loading) return <p>Cargando formatos...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  return (
+    <div className="max-w-3xl mx-auto py-8">
+      <h1 className="text-h2 font-bold mb-6">Formatos soportados</h1>
+      {data &&
+        Object.entries(data.supported_conversions).map(([source, targets]) => (
+          <div key={source} className="mb-4">
+            <h2 className="font-semibold">{source.toUpperCase()}</h2>
+            <ul className="list-disc ml-6">
+              {Object.keys(targets).map((target) => (
+                <li key={target}>{target.toUpperCase()}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+    </div>
+  );
+};
+
+export default FormatsView;

--- a/frontend/src/pages/formats.tsx
+++ b/frontend/src/pages/formats.tsx
@@ -1,0 +1,11 @@
+import FormatsView from '../components/FormatsView';
+import { Footer } from '../components/Footer';
+
+export default function FormatsPage() {
+  return (
+    <>
+      <FormatsView />
+      <Footer />
+    </>
+  );
+}

--- a/frontend/src/pages/landing.tsx
+++ b/frontend/src/pages/landing.tsx
@@ -15,6 +15,9 @@ export default function LandingPage() {
         <p className="text-xl md:text-2xl text-[#2563eb] italic">
           {t('landing.heroSubtitle')}
         </p>
+        <Link href="/formats" className="mt-6 inline-block text-[#1e40af] underline">
+          Ver formatos soportados
+        </Link>
         <motion.svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 200 200"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -170,6 +170,15 @@ export const apiService = {
     return response.json();
   },
 
+  getSupportedFormats: async (): Promise<{ supported_conversions: Record<string, Record<string, number>>; allowed_extensions: string[] }> => {
+    const response = await fetch(`${API_BASE_URL}/conversion/supported-formats`);
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'Error obteniendo formatos soportados');
+    }
+    return data;
+  },
+
   purchaseCredits: async (amount: number): Promise<any> => {
     const token = getAuthToken();
     const response = await fetch(`${API_BASE_URL}/billing/purchase`, {


### PR DESCRIPTION
## Summary
- add api service call to load supported formats
- show supported formats in new FormatsView component
- link formats page from footer and landing hero

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: Not implemented: HTMLCanvasElement.prototype.getContext)*

------
https://chatgpt.com/codex/tasks/task_e_68a320b132c88320bcfdb8cacd251ed2