### PR TITLE
docs: add encoding normalization guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cd frontend && npx vitest run --coverage
 - Procesamiento asíncrono para archivos grandes
 - Validación de entrada y manejo de errores
 - Cache inteligente para optimización
+- Normalización de codificación a UTF-8 previa a la conversión ([detalle](./docs/encoding_normalization.md))
 
 ### Sistema de Créditos
 - Compra y gestión de créditos

--- a/docs/encoding_normalization.md
+++ b/docs/encoding_normalization.md
@@ -1,0 +1,43 @@
+# Normalización de Encoding
+
+La normalización de encoding asegura que todos los archivos de texto se procesen como **UTF-8** antes de realizar cualquier conversión. Esto evita problemas de caracteres ilegibles, corrupción de datos o errores durante la conversión.
+
+## Uso de la CLI
+
+La interfaz de línea de comandos permite normalizar archivos de manera individual o en lote:
+
+```bash
+python backend/src/nexus/cli.py <archivos>
+```
+
+### Opciones disponibles
+
+- `--bom`: escribe un **Byte Order Mark (BOM)** al inicio del archivo UTF-8 resultante.
+- `--dry-run`: muestra la conversión que se realizaría sin modificar los archivos.
+- `--undo`: restaura archivos desde sus copias de respaldo (`.bak`).
+
+#### Ejemplos
+
+```bash
+# Normalizar archivo.txt a UTF-8
+python backend/src/nexus/cli.py archivo.txt
+
+# Previsualizar normalización y agregar BOM
+python backend/src/nexus/cli.py archivo.txt --dry-run --bom
+
+# Restaurar desde respaldo
+python backend/src/nexus/cli.py archivo.txt --undo
+```
+
+## Integración con el Motor de Conversión
+
+El motor de conversión invoca automáticamente la función `normalize_to_utf8` para todos los formatos de texto antes de iniciar el proceso de conversión. Esto garantiza que cada archivo tenga una codificación consistente y evita errores en etapas posteriores del flujo de conversión.
+
+Los eventos de normalización se registran en `backend/logs/encoding/encoding_normalizer.log`, facilitando la auditoría y el seguimiento de los cambios realizados.
+
+## Beneficios
+
+- Elimina problemas de **mojibake** y caracteres ilegibles.
+- Genera respaldos automáticos de los archivos originales.
+- Unifica la codificación para mantener la compatibilidad a lo largo de todo el pipeline de conversión.
+


### PR DESCRIPTION
## Summary
- document encoding normalization workflow and CLI options
- link guide from conversion engine section in README

## Testing
- `python -m pytest backend/tests/unit/test_encoding_normalizer.py` *(fails: ImportError: cannot import name 'Conversion' from 'src.models.conversion')*


------
https://chatgpt.com/codex/tasks/task_e_68a33a2982dc8320984186066c2dd3fc