### PR TITLE
feat: configurable backend port

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt
 python main.py
 
-La API expondrá un endpoint de métricas en `http://localhost:8000/metrics` y mostrará logs según el nivel definido.
+La API expondrá un endpoint de métricas en `http://localhost:${PORT:-8000}/metrics` y mostrará logs según el nivel definido. El puerto puede configurarse mediante la variable de entorno `PORT` (por defecto `8000`).
 ```
 
 ### Variables de entorno (Backend)

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,8 @@ pip install -r requirements.txt
 ```bash
 python src/main.py
 ```
-El servicio quedará disponible en `http://localhost:8000/api` con métricas en `http://localhost:8000/metrics`.
+El servicio quedará disponible en `http://localhost:${PORT:-8000}/api` con métricas en `http://localhost:${PORT:-8000}/metrics`.
+Puedes cambiar el puerto estableciendo la variable de entorno `PORT` antes de iniciar el servicio.
 
 ## Pruebas
 ```bash

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,25 +1,31 @@
 import os
 import sys
+from pathlib import Path
+
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory, jsonify, request
+import logging
+from datetime import timedelta
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from prometheus_flask_exporter import PrometheusMetrics
-import logging
+
+from src.config import get_config
 from src.models.user import db
-from src.routes.user import user_bp
 from src.routes.auth import auth_bp
 from src.routes.conversion import conversion_bp
 from src.routes.credits import credits_bp
-from datetime import timedelta
+from src.routes.user import user_bp
 from src.ws import socketio
-from src.config import get_config
-from dotenv import load_dotenv
 
-# Cargar variables de entorno desde el directorio backend
-load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
+# Cargar variables de entorno tanto desde la raíz del proyecto como desde backend/
+BASE_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(BASE_DIR.parent / ".env")
+load_dotenv(BASE_DIR / ".env")
 
 app = Flask(__name__)
 
@@ -28,144 +34,173 @@ config_class = get_config()
 app.config.from_object(config_class)
 
 # Configuración de logging
-log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
-logging.getLogger('werkzeug').setLevel(logging.WARNING)
+logging.getLogger("werkzeug").setLevel(logging.WARNING)
 metrics = PrometheusMetrics(app)
-metrics.info('app_info', 'Anclora Nexus API', version='2.0.0')
+metrics.info("app_info", "Anclora Nexus API", version="2.0.0")
 
 # Validar configuración crítica
-if not app.config.get('SECRET_KEY') or not app.config.get('JWT_SECRET_KEY'):
-    raise RuntimeError('SECRET_KEY and JWT_SECRET_KEY must be set in configuration')
+if not app.config.get("SECRET_KEY") or not app.config.get("JWT_SECRET_KEY"):
+    raise RuntimeError("SECRET_KEY and JWT_SECRET_KEY must be set in configuration")
 
 # Configuración de CORS
 CORS(
     app,
-    origins=app.config['ALLOWED_ORIGINS'],
+    origins=app.config["ALLOWED_ORIGINS"],
     supports_credentials=True,
-    allow_headers=['Content-Type', 'Authorization']
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 # Inicializar SocketIO
-socketio.init_app(app, cors_allowed_origins=app.config['ALLOWED_ORIGINS'])
+socketio.init_app(app, cors_allowed_origins=app.config["ALLOWED_ORIGINS"])
 
 # Configuración de JWT
 jwt = JWTManager(app)
 
 # Configuración de base de datos
-app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'models/database', 'app.db')}"
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config["SQLALCHEMY_DATABASE_URI"] = (
+    f"sqlite:///{os.path.join(os.path.dirname(__file__), 'models/database', 'app.db')}"
+)
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 # Inicializar base de datos
 db.init_app(app)
 
 # Registrar blueprints
-app.register_blueprint(user_bp, url_prefix='/api')
-app.register_blueprint(auth_bp, url_prefix='/api/auth')
-app.register_blueprint(conversion_bp, url_prefix='/api/conversion')
-app.register_blueprint(credits_bp, url_prefix='/api/credits')
+app.register_blueprint(user_bp, url_prefix="/api")
+app.register_blueprint(auth_bp, url_prefix="/api/auth")
+app.register_blueprint(conversion_bp, url_prefix="/api/conversion")
+app.register_blueprint(credits_bp, url_prefix="/api/credits")
 
 # Crear tablas de base de datos
 with app.app_context():
     db.create_all()
+
 
 # Registro de solicitudes
 @app.before_request
 def log_request():
     app.logger.info("%s %s", request.method, request.path)
 
+
 @app.after_request
 def log_response(response):
     app.logger.info("%s %s -> %s", request.method, request.path, response.status_code)
     return response
 
+
 # Manejador de errores JWT
 @jwt.expired_token_loader
 def expired_token_callback(jwt_header, jwt_payload):
-    return jsonify({'error': 'Token expirado'}), 401
+    return jsonify({"error": "Token expirado"}), 401
+
 
 @jwt.invalid_token_loader
 def invalid_token_callback(error):
-    return jsonify({'error': 'Token inválido'}), 401
+    return jsonify({"error": "Token inválido"}), 401
+
 
 @jwt.unauthorized_loader
 def missing_token_callback(error):
-    return jsonify({'error': 'Token de autorización requerido'}), 401
+    return jsonify({"error": "Token de autorización requerido"}), 401
+
 
 # Ruta de salud del API
-@app.route('/api/health', methods=['GET'])
+@app.route("/api/health", methods=["GET"])
 def health_check():
     """Endpoint de verificación de salud del API"""
-    return jsonify({
-        'status': 'healthy',
-        'service': 'Anclora Nexus API',
-        'version': '1.0.0',
-        'message': 'API funcionando correctamente'
-    }), 200
+    return (
+        jsonify(
+            {
+                "status": "healthy",
+                "service": "Anclora Nexus API",
+                "version": "1.0.0",
+                "message": "API funcionando correctamente",
+            }
+        ),
+        200,
+    )
+
 
 # Ruta de información del API
-@app.route('/api/info', methods=['GET'])
+@app.route("/api/info", methods=["GET"])
 def api_info():
     """Información general del API"""
-    return jsonify({
-        'name': 'Anclora Nexus API',
-        'version': '1.0.0',
-        'description': 'API para conversión inteligente de archivos',
-        'endpoints': {
-            'auth': '/api/auth',
-            'conversions': '/api/conversion',
-            'credits': '/api/credits',
-            'users': '/api/users'
-        },
-        'features': [
-            'Autenticación JWT',
-            'Sistema de créditos',
-            'Conversión de archivos',
-            'Gestión de usuarios',
-            'Historial de conversiones'
-        ]
-    }), 200
+    return (
+        jsonify(
+            {
+                "name": "Anclora Nexus API",
+                "version": "1.0.0",
+                "description": "API para conversión inteligente de archivos",
+                "endpoints": {
+                    "auth": "/api/auth",
+                    "conversions": "/api/conversion",
+                    "credits": "/api/credits",
+                    "users": "/api/users",
+                },
+                "features": [
+                    "Autenticación JWT",
+                    "Sistema de créditos",
+                    "Conversión de archivos",
+                    "Gestión de usuarios",
+                    "Historial de conversiones",
+                ],
+            }
+        ),
+        200,
+    )
+
 
 # Servir archivos estáticos del frontend
-@app.route('/', defaults={'path': ''})
-@app.route('/<path:path>')
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
 def serve(path):
     static_folder_path = app.static_folder
     if static_folder_path is None:
-        return jsonify({'error': 'Frontend no configurado'}), 404
+        return jsonify({"error": "Frontend no configurado"}), 404
 
     if path != "" and os.path.exists(os.path.join(static_folder_path, path)):
         return send_from_directory(static_folder_path, path)
     else:
-        index_path = os.path.join(static_folder_path, 'index.html')
+        index_path = os.path.join(static_folder_path, "index.html")
         if os.path.exists(index_path):
-            return send_from_directory(static_folder_path, 'index.html')
+            return send_from_directory(static_folder_path, "index.html")
         else:
-            return jsonify({
-                'message': 'Anclora Nexus API',
-                'status': 'running',
-                'frontend': 'not_configured',
-                'api_docs': '/api/info'
-            }), 200
+            return (
+                jsonify(
+                    {
+                        "message": "Anclora Nexus API",
+                        "status": "running",
+                        "frontend": "not_configured",
+                        "api_docs": "/api/info",
+                    }
+                ),
+                200,
+            )
+
 
 # Manejador de errores global
 @app.errorhandler(404)
 def not_found(error):
-    return jsonify({'error': 'Endpoint no encontrado'}), 404
+    return jsonify({"error": "Endpoint no encontrado"}), 404
+
 
 @app.errorhandler(500)
 def internal_error(error):
-    return jsonify({'error': 'Error interno del servidor'}), 500
+    return jsonify({"error": "Error interno del servidor"}), 500
+
 
 @app.errorhandler(400)
 def bad_request(error):
-    return jsonify({'error': 'Solicitud inválida'}), 400
+    return jsonify({"error": "Solicitud inválida"}), 400
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8000))
     print("Iniciando Anclora Nexus API...")
-    print("API disponible en: http://localhost:8000/api")
-    print("Información del API: http://localhost:8000/api/info")
-    print("Verificación de salud: http://localhost:8000/api/health")
+    print(f"API disponible en: http://localhost:{port}/api")
+    print(f"Información del API: http://localhost:{port}/api/info")
+    print(f"Verificación de salud: http://localhost:{port}/api/health")
     print("=" * 50)
-    app.run(host='0.0.0.0', port=8000, debug=True)
-
+    app.run(host="0.0.0.0", port=port, debug=True)

--- a/docs/DEPENDENCIAS_INSTALACION.md
+++ b/docs/DEPENDENCIAS_INSTALACION.md
@@ -37,5 +37,5 @@ python src/main.py
 ```
 
 ### Ejemplo de uso
-Envía un `POST` a `http://localhost:8000/api/conversion` con un archivo TXT y recibe el documento convertido en el formato solicitado.
+Envía un `POST` a `http://localhost:${PORT:-8000}/api/conversion` con un archivo TXT y recibe el documento convertido en el formato solicitado. Puedes modificar el puerto mediante la variable de entorno `PORT`.
 

--- a/docs/INSTALACION.md
+++ b/docs/INSTALACION.md
@@ -163,7 +163,8 @@ cd backend
 pip install -r requirements.txt
 ```
 
-Define el nivel de logging con la variable de entorno `LOG_LEVEL` y consulta las métricas en `http://localhost:8000/metrics`.
+Define el nivel de logging con la variable de entorno `LOG_LEVEL` y consulta las métricas en `http://localhost:${PORT:-8000}/metrics`.
+El puerto puede configurarse mediante la variable de entorno `PORT` (por defecto `8000`).
 
 ## 🎉 ¡Listo!
 

--- a/docs/assets/search_images/api.ts
+++ b/docs/assets/search_images/api.ts
@@ -1,8 +1,8 @@
 // Servicio de API para conectar frontend con backend
-const API_BASE_URL = 'http://localhost:8000/api';
+const API_BASE_URL = `http://localhost:${process.env.PORT || 8000}/api`;
 
 // Tipos de datos
-import type { User } from '../../../frontend/src/types/User';
+import type { User } from "../../../frontend/src/types/User";
 
 export interface LoginResponse {
   message: string;
@@ -43,29 +43,29 @@ class ApiService {
 
   constructor() {
     // Cargar token del localStorage si existe
-    this.token = localStorage.getItem('auth_token');
+    this.token = localStorage.getItem("auth_token");
   }
 
   // Configurar token de autenticación
   setToken(token: string) {
     this.token = token;
-    localStorage.setItem('auth_token', token);
+    localStorage.setItem("auth_token", token);
   }
 
   // Limpiar token
   clearToken() {
     this.token = null;
-    localStorage.removeItem('auth_token');
+    localStorage.removeItem("auth_token");
   }
 
   // Obtener headers con autenticación
   private getHeaders(includeAuth: boolean = true): HeadersInit {
     const headers: HeadersInit = {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     };
 
     if (includeAuth && this.token) {
-      headers['Authorization'] = `Bearer ${this.token}`;
+      headers["Authorization"] = `Bearer ${this.token}`;
     }
 
     return headers;
@@ -75,10 +75,10 @@ class ApiService {
   private async request<T>(
     endpoint: string,
     options: RequestInit = {},
-    includeAuth: boolean = true
+    includeAuth: boolean = true,
   ): Promise<T> {
     const url = `${API_BASE_URL}${endpoint}`;
-    
+
     const config: RequestInit = {
       ...options,
       headers: {
@@ -89,10 +89,12 @@ class ApiService {
 
     try {
       const response = await fetch(url, config);
-      
+
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
+        throw new Error(
+          errorData.error || `HTTP ${response.status}: ${response.statusText}`,
+        );
       }
 
       return await response.json();
@@ -104,20 +106,28 @@ class ApiService {
 
   // Autenticación
   async register(data: RegisterData): Promise<LoginResponse> {
-    const response = await this.request<LoginResponse>('/auth/register', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }, false);
+    const response = await this.request<LoginResponse>(
+      "/auth/register",
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+      false,
+    );
 
     this.setToken(response.access_token);
     return response;
   }
 
   async login(data: LoginData): Promise<LoginResponse> {
-    const response = await this.request<LoginResponse>('/auth/login', {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }, false);
+    const response = await this.request<LoginResponse>(
+      "/auth/login",
+      {
+        method: "POST",
+        body: JSON.stringify(data),
+      },
+      false,
+    );
 
     this.setToken(response.access_token);
     return response;
@@ -128,19 +138,27 @@ class ApiService {
   }
 
   async getProfile(): Promise<{ user: User }> {
-    return await this.request<{ user: User }>('/auth/profile');
+    return await this.request<{ user: User }>("/auth/profile");
   }
 
-  async updateProfile(data: Partial<User>): Promise<{ user: User; message: string }> {
-    return await this.request<{ user: User; message: string }>('/auth/profile', {
-      method: 'PUT',
-      body: JSON.stringify(data),
-    });
+  async updateProfile(
+    data: Partial<User>,
+  ): Promise<{ user: User; message: string }> {
+    return await this.request<{ user: User; message: string }>(
+      "/auth/profile",
+      {
+        method: "PUT",
+        body: JSON.stringify(data),
+      },
+    );
   }
 
-  async changePassword(currentPassword: string, newPassword: string): Promise<{ message: string }> {
-    return await this.request<{ message: string }>('/auth/change-password', {
-      method: 'POST',
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<{ message: string }> {
+    return await this.request<{ message: string }>("/auth/change-password", {
+      method: "POST",
       body: JSON.stringify({
         current_password: currentPassword,
         new_password: newPassword,
@@ -149,44 +167,51 @@ class ApiService {
   }
 
   async verifyToken(): Promise<{ valid: boolean; user: User }> {
-    return await this.request<{ valid: boolean; user: User }>('/auth/verify-token');
+    return await this.request<{ valid: boolean; user: User }>(
+      "/auth/verify-token",
+    );
   }
 
   // Conversiones
   async convertFile(data: ConversionRequest): Promise<ConversionResponse> {
     const formData = new FormData();
-    formData.append('file', data.file);
-    formData.append('target_format', data.target_format);
+    formData.append("file", data.file);
+    formData.append("target_format", data.target_format);
     if (data.quality) {
-      formData.append('quality', data.quality);
+      formData.append("quality", data.quality);
     }
 
     const response = await fetch(`${API_BASE_URL}/conversion/convert`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Authorization': `Bearer ${this.token}`,
+        Authorization: `Bearer ${this.token}`,
       },
       body: formData,
     });
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
+      throw new Error(
+        errorData.error || `HTTP ${response.status}: ${response.statusText}`,
+      );
     }
 
     return await response.json();
   }
 
   async getConversionHistory(): Promise<{ conversions: any[] }> {
-    return await this.request<{ conversions: any[] }>('/conversion/history');
+    return await this.request<{ conversions: any[] }>("/conversion/history");
   }
 
   async downloadConversion(conversionId: number): Promise<Blob> {
-    const response = await fetch(`${API_BASE_URL}/conversion/download/${conversionId}`, {
-      headers: {
-        'Authorization': `Bearer ${this.token}`,
+    const response = await fetch(
+      `${API_BASE_URL}/conversion/download/${conversionId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+        },
       },
-    });
+    );
 
     if (!response.ok) {
       throw new Error(`Error downloading file: ${response.statusText}`);
@@ -197,26 +222,44 @@ class ApiService {
 
   // Créditos
   async getCreditBalance(): Promise<{ balance: number; transactions: any[] }> {
-    return await this.request<{ balance: number; transactions: any[] }>('/credits/balance');
+    return await this.request<{ balance: number; transactions: any[] }>(
+      "/credits/balance",
+    );
   }
 
-  async purchaseCredits(amount: number): Promise<{ message: string; new_balance: number }> {
-    return await this.request<{ message: string; new_balance: number }>('/credits/purchase', {
-      method: 'POST',
-      body: JSON.stringify({ amount }),
-    });
+  async purchaseCredits(
+    amount: number,
+  ): Promise<{ message: string; new_balance: number }> {
+    return await this.request<{ message: string; new_balance: number }>(
+      "/credits/purchase",
+      {
+        method: "POST",
+        body: JSON.stringify({ amount }),
+      },
+    );
   }
 
   async upgradePlan(newPlan: string): Promise<{ message: string; user: User }> {
-    return await this.request<{ message: string; user: User }>('/credits/upgrade-plan', {
-      method: 'POST',
-      body: JSON.stringify({ plan: newPlan }),
-    });
+    return await this.request<{ message: string; user: User }>(
+      "/credits/upgrade-plan",
+      {
+        method: "POST",
+        body: JSON.stringify({ plan: newPlan }),
+      },
+    );
   }
 
   // Verificar salud del API
-  async healthCheck(): Promise<{ status: string; service: string; version: string }> {
-    return await this.request<{ status: string; service: string; version: string }>('/health', {}, false);
+  async healthCheck(): Promise<{
+    status: string;
+    service: string;
+    version: string;
+  }> {
+    return await this.request<{
+      status: string;
+      service: string;
+      version: string;
+    }>("/health", {}, false);
   }
 }
 
@@ -241,29 +284,32 @@ export const isTokenValid = async (): Promise<boolean> => {
 export const formatFileSize = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 };
 
-export const getConversionCost = (fromFormat: string, toFormat: string): number => {
+export const getConversionCost = (
+  fromFormat: string,
+  toFormat: string,
+): number => {
   const conversionKey = `${fromFormat.toLowerCase()}-${toFormat.toLowerCase()}`;
-  
+
   // Costos básicos por tipo de conversión
   const costs: Record<string, number> = {
-    'txt-html': 1,
-    'txt-pdf': 1,
-    'txt-doc': 2,
-    'txt-docx': 2,
-    'txt-md': 1,
-    'txt-rtf': 1,
-    'txt-odt': 2,
-    'txt-tex': 3,
-    'pdf-jpg': 3,
-    'pdf-png': 3,
-    'jpg-png': 1,
-    'png-jpg': 1,
+    "txt-html": 1,
+    "txt-pdf": 1,
+    "txt-doc": 2,
+    "txt-docx": 2,
+    "txt-md": 1,
+    "txt-rtf": 1,
+    "txt-odt": 2,
+    "txt-tex": 3,
+    "pdf-jpg": 3,
+    "pdf-png": 3,
+    "jpg-png": 1,
+    "png-jpg": 1,
   };
 
   return costs[conversionKey] || 2; // Costo por defecto
 };
-

--- a/docs/guides/MANUAL_EJECUCION_Y_PRUEBAS.md
+++ b/docs/guides/MANUAL_EJECUCION_Y_PRUEBAS.md
@@ -151,9 +151,9 @@ python src\main.py
 **¿Qué verás?**
 ```
 Iniciando Anclora Nexus API...
-API disponible en: http://localhost:8000/api
-Información del API: http://localhost:8000/api/info
-Verificación de salud: http://localhost:8000/api/health
+API disponible en: http://localhost:${PORT:-8000}/api
+Información del API: http://localhost:${PORT:-8000}/api/info
+Verificación de salud: http://localhost:${PORT:-8000}/api/health
 ==================================================
  * Serving Flask app 'main'
  * Debug mode: on
@@ -194,7 +194,7 @@ npm run dev
 
 ```powershell
 # Probar el endpoint de salud
-curl "http://localhost:8000/api/health"
+curl "http://localhost:${PORT:-8000}/api/health"
 ```
 
 **Respuesta esperada**:
@@ -235,7 +235,7 @@ Para probar una conversión desde la terminal:
 "Hola mundo. Esta es una prueba de conversión." | Out-File -FilePath "prueba.txt" -Encoding utf8
 
 # Probar conversión TXT a PDF
-curl -X POST "http://localhost:8000/api/convert" `
+curl -X POST "http://localhost:${PORT:-8000}/api/convert" `
   -H "Content-Type: application/json" `
   -d '{"input_format": "txt", "output_format": "pdf", "content": "Texto de prueba para conversión a PDF"}'
 ```
@@ -291,8 +291,8 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ### Problema: "Puerto ya está en uso"
 **Solución**:
 ```powershell
-# Verificar qué proceso usa el puerto 8000
-netstat -ano | findstr :8000
+# Verificar qué proceso usa el puerto configurado (por defecto 8000)
+netstat -ano | findstr :${PORT:-8000}
 # Matar el proceso si es necesario
 taskkill /PID [número_de_proceso] /F
 ```
@@ -343,7 +343,7 @@ Los mensajes aparecen en la terminal donde ejecutas `npm run dev`.
 ### Verificar Estado de los Servicios:
 ```powershell
 # Backend
-curl "http://localhost:8000/api/health"
+curl "http://localhost:${PORT:-8000}/api/health"
 
 # Frontend (en navegador)
 # http://localhost:5173
@@ -367,7 +367,7 @@ node --version
 npm --version
 
 # Verificar procesos
-netstat -ano | findstr :8000
+netstat -ano | findstr :${PORT:-8000}
 netstat -ano | findstr :5173
 
 # Verificar entorno virtual
@@ -385,7 +385,7 @@ Antes de usar la aplicación, verifica que:
 - [ ] Node.js 18+ está instalado  
 - [ ] VS Code está abierto con el proyecto
 - [ ] Entorno virtual está activo (ves `(.venv)` en la terminal)
-- [ ] Backend ejecutándose en puerto 8000
+- [ ] Backend ejecutándose en el puerto configurado (PORT, por defecto 8000)
 - [ ] Frontend ejecutándose en puerto 5173
 - [ ] Ambos servicios responden correctamente
 - [ ] Puedes acceder a http://localhost:5173 en el navegador

--- a/docs/project-analysis/FASE_3_COMPLETADA.md
+++ b/docs/project-analysis/FASE_3_COMPLETADA.md
@@ -34,10 +34,10 @@ app.config.from_object(get_config())
 
 ## 🧪 Verificación de Funcionamiento
 
-### ✅ Backend (Puerto 8000)
+### ✅ Backend (Puerto configurable)
 ```bash
 # Estado: FUNCIONANDO ✅
-- API Health Check: http://localhost:8000/api/health
+- API Health Check: http://localhost:${PORT:-8000}/api/health
 - Respuesta: {"status": "healthy", "service": "Anclora Nexus API"}
 - Configuración centralizada: ACTIVA
 - Flask Debug Mode: ACTIVO

--- a/docs/project-analysis/FRONTEND_FIX_SUMMARY.md
+++ b/docs/project-analysis/FRONTEND_FIX_SUMMARY.md
@@ -40,7 +40,7 @@ VITE v7.1.2 ready
 ➜ Local: http://127.0.0.1:5173/
 ```
 
-### ✅ **Backend (Puerto 8000)**
+### ✅ **Backend (Puerto configurable, por defecto 8000)**
 ```json
 {
   "message": "API funcionando correctamente",


### PR DESCRIPTION
## Summary
- make backend port configurable via `PORT` environment variable
- load environment variables from project root
- document configurable port across docs

## Testing
- `cd backend && python -m pytest tests/` *(fails: AssertionError in sqlalchemy due to TypingOnly inheritance)*
- `npx prettier docs/assets/search_images/api.ts -w`

------
https://chatgpt.com/codex/tasks/task_e_68af62bface08320989f77f42d216b09