### PR TITLE
Fix progress event percent emission and add tests

### DIFF
--- a/backend/src/ws.py
+++ b/backend/src/ws.py
@@ -18,7 +18,10 @@ class Phase(str, Enum):
 def emit_progress(conversion_id: int, phase: Union[Phase, str], percent: int) -> None:
     """Broadcast conversion progress to all connected clients."""
     try:
-        socketio.emit("conversion_progress", {"conversion_id": conversion_id, "progress": progress})
+        socketio.emit(
+            "conversion_progress",
+            {"conversion_id": conversion_id, "phase": phase, "percent": percent},
+        )
     except Exception:
         # Durante las pruebas el servidor SocketIO no está inicializado
         pass

--- a/backend/tests/test_ws.py
+++ b/backend/tests/test_ws.py
@@ -1,0 +1,24 @@
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "ws", Path(__file__).resolve().parent / "../src/ws.py"
+)
+ws = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ws)
+
+
+def test_emit_progress_emits_correct_event(monkeypatch):
+    emitted = {}
+
+    def fake_emit(event, data):
+        emitted['event'] = event
+        emitted['data'] = data
+
+    monkeypatch.setattr(ws.socketio, 'emit', fake_emit)
+
+    ws.emit_progress(1, 'convert', 50)
+
+    assert emitted['event'] == 'conversion_progress'
+    assert emitted['data'] == {'conversion_id': 1, 'phase': 'convert', 'percent': 50}


### PR DESCRIPTION
## Summary
- emit phase and percent in `conversion_progress` websocket event
- add unit test for websocket progress emission

## Testing
- `cd backend && pytest tests/test_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7162eecc832081fba5b6fa2d8325