### PR TITLE
fix: Remove old step progress indicator from conversion engine

### DIFF
--- a/frontend/src/components/NewConversorInteligente.tsx
+++ b/frontend/src/components/NewConversorInteligente.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/NewConversorInteligente.tsx
 import React, { useState, useCallback } from 'react';
-import { Card, CardHeader, CardTitle, CardContent, Badge, FileUpload, StepProgress, Progress } from './ui';
+import { Card, CardHeader, CardTitle, CardContent, Badge, FileUpload, Progress } from './ui';
 import {
   FileUp, FileBarChart, Settings, Download, ArrowRight, Check, Loader, Brain, Zap, Eye
 } from 'lucide-react';
@@ -294,17 +294,7 @@ export const NewConversorInteligente: React.FC = () => {
         </div>
       </div>
 
-      {/* Indicador de progreso */}
-      <div className="flex justify-center mb-8">
-        <div className="w-full max-w-xl">
-          <StepProgress
-            steps={4}
-            currentStep={currentStep}
-            labels={['Subir', 'Análisis IA', 'Configurar', 'Descargar']}
-            className="animate-in fade-in duration-500"
-          />
-        </div>
-      </div>
+
 
       {/* Tarjetas de proceso */}
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">


### PR DESCRIPTION
## 🎯 **Objective**

Remove the legacy step progress indicator component from the conversion engine screen to eliminate visual conflicts with the new circular progress indicator implemented in the `feature/conversion-ui-refresh` branch.

## 📋 **Changes Made**

### ✅ **Removed Components:**
- **Legacy StepProgress component** from `NewConversorInteligente.tsx` (lines 297-307)
- **StepProgress import** that was no longer needed
- **Old conversion workflow steps** display

### ✅ **Preserved Components:**
- **CircularProgress component** remains functional in `SafeConversor.tsx`
- **Modern progress system** from `feature/conversion-ui-refresh` intact
- **All conversion functionality** preserved

## 🔧 **Technical Details**

**Files Modified:**
- `frontend/src/components/NewConversorInteligente.tsx`
  - Removed old step progress indicator section
  - Cleaned up unused StepProgress import
  - Maintained all other functionality

**Impact:**
- ✅ Eliminates visual conflicts between old and new progress indicators
- ✅ Maintains only the updated circular progress system
- ✅ Cleaner UI without redundant progress components
- ✅ No breaking changes to conversion functionality

## 🧪 **Testing**

- [x] Verified SafeConversor.tsx still uses CircularProgress correctly
- [x] Confirmed no unused imports remain
- [x] Ensured conversion functionality is preserved
- [x] Validated clean removal without side effects

## 📸 **Before vs After**

**Before:** Had both old step progress indicator AND new circular progress
**After:** Clean UI with only the modern circular progress indicator

---

**Related:** This completes the UI refresh from `feature/conversion-ui-refresh` by removing legacy components that were causing visual conflicts.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author